### PR TITLE
Potential fix for code scanning alert no. 2: Incomplete URL substring sanitization

### DIFF
--- a/tests/integration/network/unrestricted/test_unrestricted.py
+++ b/tests/integration/network/unrestricted/test_unrestricted.py
@@ -49,7 +49,12 @@ class TestUnrestrictedNetwork:
         result = await shared_sandbox.execute("getent hosts google.com", timeout=10.0)
         # getent should succeed if DNS is working
         assert result.exit_code == 0, f"DNS resolution failed: {result.stderr}"
-        assert "google.com" in result.stdout, "Expected hostname in getent output"
+
+        # Parse getent output and require google.com as a hostname token,
+        # not merely a substring at an arbitrary position.
+        lines = [line.split() for line in result.stdout.splitlines() if line.strip()]
+        has_google_host = any(len(fields) >= 2 and "google.com" in fields[1:] for fields in lines)
+        assert has_google_host, "Expected google.com hostname token in getent output"
 
     @pytest.mark.asyncio
     async def test_curl_https(self, shared_sandbox):

--- a/tests/integration/network/unrestricted/test_unrestricted.py
+++ b/tests/integration/network/unrestricted/test_unrestricted.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+from urllib.parse import urlsplit
 
 import pytest
 
@@ -50,10 +51,21 @@ class TestUnrestrictedNetwork:
         # getent should succeed if DNS is working
         assert result.exit_code == 0, f"DNS resolution failed: {result.stderr}"
 
-        # Parse getent output and require google.com as a hostname token,
-        # not merely a substring at an arbitrary position.
+        # Parse getent output and require google.com (or subdomain) as a
+        # hostname token with proper host-boundary validation.
         lines = [line.split() for line in result.stdout.splitlines() if line.strip()]
-        has_google_host = any(len(fields) >= 2 and "google.com" in fields[1:] for fields in lines)
+        has_google_host = False
+        for fields in lines:
+            if len(fields) < 2:
+                continue
+            for token in fields[1:]:
+                normalized = token.rstrip(".").lower()
+                host = urlsplit(f"//{normalized}").hostname
+                if host and (host == "google.com" or host.endswith(".google.com")):
+                    has_google_host = True
+                    break
+            if has_google_host:
+                break
         assert has_google_host, "Expected google.com hostname token in getent output"
 
     @pytest.mark.asyncio


### PR DESCRIPTION
Potential fix for [https://github.com/microsoft/quicksand/security/code-scanning/2](https://github.com/microsoft/quicksand/security/code-scanning/2)

To fix this, avoid checking for `google.com` as an arbitrary substring in command output. Instead, parse `getent hosts` output line-by-line and validate that at least one line contains `google.com` as a hostname token (exact token match), not as part of another string.

Best minimal fix in `tests/integration/network/unrestricted/test_unrestricted.py`:
- Keep the existing `exit_code` assertion.
- Replace line 52’s substring assertion with tokenized parsing:
  - split stdout into lines,
  - split each line into whitespace-separated fields,
  - ignore malformed lines (fewer than 2 fields),
  - check whether `google.com` appears in the hostname fields (`fields[1:]`).
- Assert that such a line exists.

No new imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
