### PR TITLE
fix(quicksand-core): shell-quote paths in mount/umount commands

### DIFF
--- a/packages/quicksand-core/quicksand_core/sandbox/_mounts.py
+++ b/packages/quicksand-core/quicksand_core/sandbox/_mounts.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import logging
+import shlex
 
 from .._types import MountHandle, MountOptions, NetworkConstants, NetworkMode, Timeouts
 from ..host.smb import SMBServer, create_smb_server
@@ -39,12 +40,13 @@ class _MountMixin(_SandboxProtocol):
     async def _mount_9p_share(self, tag: str, guest_path: str, readonly: bool) -> None:
         """Mount a virtio-9p share inside the guest."""
         await self.execute(
-            f"sudo mkdir -p {guest_path}",
+            f"sudo mkdir -p {shlex.quote(guest_path)}",
             timeout=Timeouts.MOUNT_OPERATION,
         )
         ro_opt = ",ro" if readonly else ""
         result = await self.execute(
-            f"sudo mount -t 9p -o trans=virtio,version=9p2000.L{ro_opt} {tag} {guest_path}",
+            f"sudo mount -t 9p -o trans=virtio,version=9p2000.L{ro_opt}"
+            f" {shlex.quote(tag)} {shlex.quote(guest_path)}",
             timeout=Timeouts.MOUNT_OPERATION,
         )
         if result.exit_code != 0:
@@ -57,7 +59,7 @@ class _MountMixin(_SandboxProtocol):
         assert self._smb_server is not None
 
         await self.execute(
-            f"sudo mkdir -p {guest_path}",
+            f"sudo mkdir -p {shlex.quote(guest_path)}",
             timeout=Timeouts.MOUNT_OPERATION,
         )
 
@@ -77,8 +79,9 @@ class _MountMixin(_SandboxProtocol):
         username, password = self._smb_server.credentials
         cifs_opts = MountOptions.cifs_opts(username, password)
         mount_cmd = (
-            f"sudo mount -t cifs //{gateway}/{share_name} {guest_path} "
-            f"-o {cifs_opts},port={port}{ro_opt}"
+            f"sudo mount -t cifs //{gateway}/{shlex.quote(share_name)}"
+            f" {shlex.quote(guest_path)}"
+            f" -o {shlex.quote(cifs_opts)},port={port}{ro_opt}"
         )
 
         last_error = ""
@@ -141,13 +144,13 @@ class _MountMixin(_SandboxProtocol):
             for guest_path in reversed(mounted_9p):
                 with contextlib.suppress(Exception):
                     await self.execute(
-                        f"sudo umount {guest_path}",
+                        f"sudo umount {shlex.quote(guest_path)}",
                         timeout=Timeouts.MOUNT_OPERATION,
                     )
             for share_name, guest_path in reversed(mounted_cifs):
                 with contextlib.suppress(Exception):
                     await self.execute(
-                        f"sudo umount {guest_path}",
+                        f"sudo umount {shlex.quote(guest_path)}",
                         timeout=Timeouts.MOUNT_OPERATION,
                     )
                 with contextlib.suppress(Exception):
@@ -209,7 +212,10 @@ class _MountMixin(_SandboxProtocol):
         Args:
             handle: The MountHandle returned by mount().
         """
-        result = await self.execute(f"sudo umount {handle.guest}", timeout=Timeouts.MOUNT_OPERATION)
+        result = await self.execute(
+            f"sudo umount {shlex.quote(handle.guest)}",
+            timeout=Timeouts.MOUNT_OPERATION,
+        )
         if result.exit_code != 0:
             logger.warning(
                 "umount %s failed: %s",
@@ -240,7 +246,7 @@ class _MountMixin(_SandboxProtocol):
         for handle in reversed(self._dynamic_mounts):
             with contextlib.suppress(Exception):
                 await self.execute(
-                    f"sudo umount {handle.guest}",
+                    f"sudo umount {shlex.quote(handle.guest)}",
                     timeout=Timeouts.MOUNT_OPERATION,
                 )
         self._dynamic_mounts.clear()

--- a/tests/unit/test_mounts.py
+++ b/tests/unit/test_mounts.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import contextlib
+import shlex
 from typing import ClassVar
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -369,3 +370,96 @@ class TestCifsOpts:
         """Test that cifs_opts produces sec=none for empty password."""
         result = MountOptions.cifs_opts("guest", "")
         assert result == "username=guest,password=,sec=none,vers=3.0"
+
+
+_PATHS_WITH_SPECIAL_CHARS = [
+    "/sessions/1/mounts/path with whitespace",
+    "/sessions/1/mounts/folder (parens)",
+    "/sessions/1/mounts/sam's-files",
+    "/sessions/1/mounts/日本語",
+]
+
+
+class TestSpecialCharsInPath:
+    """Mount/umount commands preserve the guest path verbatim, even when it
+    contains shell-special characters that would otherwise be split or
+    interpreted by the guest shell."""
+
+    @pytest.mark.parametrize("path", _PATHS_WITH_SPECIAL_CHARS)
+    @pytest.mark.asyncio
+    async def test_cifs_mount_preserves_path(self, path):
+        commands = []
+
+        def mock_execute(cmd: str, timeout: float) -> ExecuteResult:
+            commands.append(cmd)
+            return ExecuteResult(stdout="", stderr="", exit_code=0)
+
+        mock_server = MagicMock()
+        mock_server.credentials = ("guest", "")
+
+        sb = _MockSandbox(mock_execute, [])
+        sb._smb_server = mock_server
+
+        await sb._mount_cifs_share("QUICKSAND0", path, False)
+
+        mount_cmd = next(c for c in commands if "mount -t cifs" in c)
+        assert path in shlex.split(mount_cmd), mount_cmd
+
+    @pytest.mark.parametrize("path", _PATHS_WITH_SPECIAL_CHARS)
+    @pytest.mark.asyncio
+    async def test_cifs_mkdir_preserves_path(self, path):
+        commands = []
+
+        def mock_execute(cmd: str, timeout: float) -> ExecuteResult:
+            commands.append(cmd)
+            return ExecuteResult(stdout="", stderr="", exit_code=0)
+
+        mock_server = MagicMock()
+        mock_server.credentials = ("guest", "")
+
+        sb = _MockSandbox(mock_execute, [])
+        sb._smb_server = mock_server
+
+        await sb._mount_cifs_share("QUICKSAND0", path, False)
+
+        mkdir_cmd = next(c for c in commands if "mkdir -p" in c)
+        assert path in shlex.split(mkdir_cmd), mkdir_cmd
+
+    @pytest.mark.parametrize("path", _PATHS_WITH_SPECIAL_CHARS)
+    @pytest.mark.asyncio
+    async def test_unmount_preserves_path(self, path):
+        commands = []
+
+        def mock_execute(cmd: str, timeout: float) -> ExecuteResult:
+            commands.append(cmd)
+            return ExecuteResult(stdout="", stderr="", exit_code=0)
+
+        sb = _MockSandbox(mock_execute, [])
+        sb._smb_server = MagicMock()
+
+        handle = MountHandle(
+            host="/dummy/host",
+            guest=path,
+            readonly=False,
+            _share_name="QUICKSAND0",
+        )
+        await sb.unmount(handle)
+
+        umount_cmd = next(c for c in commands if "umount" in c)
+        assert path in shlex.split(umount_cmd), umount_cmd
+
+    @pytest.mark.parametrize("path", _PATHS_WITH_SPECIAL_CHARS)
+    @pytest.mark.asyncio
+    async def test_9p_mount_preserves_path(self, path):
+        commands = []
+
+        def mock_execute(cmd: str, timeout: float) -> ExecuteResult:
+            commands.append(cmd)
+            return ExecuteResult(stdout="", stderr="", exit_code=0)
+
+        sb = _MockSandbox(mock_execute, [])
+
+        await sb._mount_9p_share("pb9p0", path, False)
+
+        mount_cmd = next(c for c in commands if "mount -t 9p" in c)
+        assert path in shlex.split(mount_cmd), mount_cmd


### PR DESCRIPTION
## Bug

Mounting a guest directory whose path contains a space (or other shell-special characters) fails with `mount: bad usage`, even though the path is valid.

Expected: any path the OS accepts as a directory name should mount successfully, regardless of which characters it contains.

## Fix

Shell-quote every interpolated path before passing it to the guest shell, so the path reaches the mount/umount/mkdir command as a single argument.

## Out of scope

QEMU's `-fsdev` option string also interpolates a host path, but goes through subprocess argv rather than a shell. It could mis-parse a host path containing a comma (QEMU uses comma-separated options) — different injection layer, tracked separately.
