### PR TITLE
fix(qemu): hard-fail Linux bundling on missing patchelf or unresolved libs

### DIFF
--- a/packages/dev/quicksand-build-tools/quicksand_build_tools/__init__.py
+++ b/packages/dev/quicksand-build-tools/quicksand_build_tools/__init__.py
@@ -115,6 +115,14 @@ class BinaryBundler:
 
         Clears library path env vars to force using only bundled libs,
         then runs the binary with --version.
+
+        On Linux, additionally re-runs ``ldd`` against the bundled binary
+        and asserts every NEEDED entry resolves to either a bundled lib
+        (under ``bin_dir``) or a SYSTEM_LIBS-blocklist lib.  Without this,
+        a ``--version`` run on the build machine succeeds even when libs
+        the bundler missed are silently picked up from ``/usr/lib`` via
+        ``/etc/ld.so.cache`` — producing wheels that break on hosts that
+        don't happen to have those libs installed.
         """
         env = {k: v for k, v in os.environ.items() if not k.startswith(("DYLD_", "LD_LIBRARY"))}
 
@@ -146,7 +154,74 @@ class BinaryBundler:
                 f"  Stderr: {result.stderr}\n"
                 "A required library dependency was not bundled correctly."
             )
+
+        if platform.system().lower() == "linux":
+            self._verify_linux_isolation(binary, bin_dir)
+
         self.app.display_info(f"Verified: {binary.name}")
+
+    def _verify_linux_isolation(self, binary: Path, bin_dir: Path) -> None:
+        """Assert ldd resolves every NEEDED lib to a bundled or blocklisted path.
+
+        Runs ``ldd`` against the bundled binary with ``LD_LIBRARY_PATH``
+        scrubbed (the binary's RPATH is what should be doing the work).
+        Any lib that resolves into a system path like ``/usr/lib/...`` —
+        and is not in the SYSTEM_LIBS blocklist — means the bundler
+        missed it and the wheel will break on hosts without that lib.
+        """
+        env = {k: v for k, v in os.environ.items() if not k.startswith(("DYLD_", "LD_LIBRARY"))}
+        result = subprocess.run(
+            ["ldd", str(binary)],
+            capture_output=True,
+            text=True,
+            env=env,
+            timeout=30,
+        )
+        if result.returncode != 0:
+            raise RuntimeError(f"ldd failed against bundled {binary.name}:\n{result.stderr}")
+
+        bin_dir_resolved = bin_dir.resolve()
+        blocklist = SYSTEM_LIBS["linux"]
+        leaked: list[str] = []
+        not_found: list[str] = []
+
+        for line in result.stdout.splitlines():
+            line = line.strip()
+            if "=>" not in line:
+                continue
+            if "not found" in line:
+                not_found.append(line)
+                continue
+            parts = line.split("=>")
+            if len(parts) != 2:
+                continue
+            lib_path = parts[1].strip().split()[0]
+            if not lib_path.startswith("/"):
+                continue
+
+            lib_name = Path(lib_path).name.lower()
+            if any(lib_name.startswith(prefix) for prefix in blocklist):
+                continue
+
+            try:
+                Path(lib_path).resolve().relative_to(bin_dir_resolved)
+            except ValueError:
+                leaked.append(f"{Path(lib_path).name} <- {lib_path}")
+
+        if not_found or leaked:
+            msgs: list[str] = []
+            if not_found:
+                msgs.append("Unresolved NEEDED libs:\n  " + "\n  ".join(not_found))
+            if leaked:
+                msgs.append(
+                    "Bundled binary resolved against system libs (not bundled):\n  "
+                    + "\n  ".join(leaked)
+                )
+            raise RuntimeError(
+                f"Verification of bundled {binary.name} failed:\n"
+                + "\n".join(msgs)
+                + "\nThe wheel would break on hosts missing these libs."
+            )
 
     def set_platform_wheel_tag(self, build_data: dict) -> None:
         """Set build_data fields for a platform-specific py3-none wheel.
@@ -325,8 +400,13 @@ class BinaryBundler:
     def bundle_linux_libs(self, binary: Path, bin_dir: Path) -> None:
         """Copy shared library dependencies and set RPATH for Linux."""
         if not shutil.which("patchelf"):
-            self.app.display_warning("patchelf not found, skipping library bundling")
-            return
+            raise RuntimeError(
+                "patchelf is required to bundle Linux shared libraries.\n"
+                "Without it, the wheel ships QEMU with no bundled deps and no\n"
+                "RPATH, which only works on hosts that already have every\n"
+                "QEMU runtime dep installed system-wide.\n"
+                "Install with:  sudo apt-get install patchelf  (or dnf)."
+            )
 
         lib_dir = bin_dir / "lib"
         lib_dir.mkdir(exist_ok=True)
@@ -350,8 +430,13 @@ class BinaryBundler:
             text=True,
         )
 
+        not_found: list[str] = []
         for line in result.stdout.splitlines():
-            if "=>" not in line or "not found" in line:
+            if "=>" not in line:
+                continue
+
+            if "not found" in line:
+                not_found.append(line.strip())
                 continue
 
             parts = line.split("=>")
@@ -375,6 +460,17 @@ class BinaryBundler:
                     ["patchelf", "--set-rpath", "$ORIGIN", str(dest)],
                     capture_output=True,
                 )
+
+        if not_found:
+            joined = "\n  ".join(not_found)
+            raise RuntimeError(
+                f"ldd reported unresolved NEEDED libraries for {binary}:\n"
+                f"  {joined}\n"
+                "The build runner is missing these libs, so they cannot be\n"
+                "bundled.  Install the corresponding system packages on the\n"
+                "runner before building.  Shipping the wheel without them\n"
+                "would silently break on hosts that don't have them."
+            )
 
     # -----------------------------------------------------------------
     # Windows

--- a/packages/dev/quicksand-build-tools/quicksand_build_tools/__init__.py
+++ b/packages/dev/quicksand-build-tools/quicksand_build_tools/__init__.py
@@ -116,13 +116,21 @@ class BinaryBundler:
         Clears library path env vars to force using only bundled libs,
         then runs the binary with --version.
 
-        On Linux, additionally re-runs ``ldd`` against the bundled binary
-        and asserts every NEEDED entry resolves to either a bundled lib
-        (under ``bin_dir``) or a SYSTEM_LIBS-blocklist lib.  Without this,
-        a ``--version`` run on the build machine succeeds even when libs
-        the bundler missed are silently picked up from ``/usr/lib`` via
-        ``/etc/ld.so.cache`` — producing wheels that break on hosts that
-        don't happen to have those libs installed.
+        Additionally runs a platform-specific isolation check that
+        catches the failure mode where the bundler missed a lib but the
+        ``--version`` run still succeeds because the build machine has
+        the lib installed system-wide:
+
+        - **Linux**: re-runs ``ldd`` and asserts every NEEDED entry
+          resolves under ``bin_dir`` or matches the SYSTEM_LIBS
+          blocklist.
+        - **macOS**: parses ``otool -L`` and asserts every load command
+          is ``@loader_path/...``, ``/usr/lib/...``, or
+          ``/System/Library/...``.  Anything from ``/opt/homebrew/`` or
+          similar means the bundler missed a dylib.
+        - **Windows**: re-runs ``--version`` with PATH scrubbed to just
+          ``%SystemRoot%\\System32`` so the loader can only resolve DLLs
+          via the binary's app-dir (``bin_dir``) or System32.
         """
         env = {k: v for k, v in os.environ.items() if not k.startswith(("DYLD_", "LD_LIBRARY"))}
 
@@ -155,8 +163,13 @@ class BinaryBundler:
                 "A required library dependency was not bundled correctly."
             )
 
-        if platform.system().lower() == "linux":
+        system = platform.system().lower()
+        if system == "linux":
             self._verify_linux_isolation(binary, bin_dir)
+        elif system == "darwin":
+            self._verify_macos_isolation(binary, bin_dir)
+        elif system == "windows":
+            self._verify_windows_isolation(binary, bin_dir)
 
         self.app.display_info(f"Verified: {binary.name}")
 
@@ -221,6 +234,92 @@ class BinaryBundler:
                 f"Verification of bundled {binary.name} failed:\n"
                 + "\n".join(msgs)
                 + "\nThe wheel would break on hosts missing these libs."
+            )
+
+    def _verify_macos_isolation(self, binary: Path, bin_dir: Path) -> None:
+        """Assert otool -L resolves every load command to @loader_path or system.
+
+        Apple frameworks ship in the dyld shared cache and must be loaded
+        via ``/usr/lib/...`` or ``/System/Library/...``.  Anything else
+        absolute (e.g. ``/opt/homebrew/Cellar/...``) means
+        ``install_name_tool`` did not rewrite the load command — i.e.
+        ``bundle_macos_dylibs`` skipped that dylib — and the wheel will
+        fail to load on machines without that exact path.
+        """
+        result = subprocess.run(
+            ["otool", "-L", str(binary)],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        if result.returncode != 0:
+            raise RuntimeError(f"otool -L failed against bundled {binary.name}:\n{result.stderr}")
+
+        leaked: list[str] = []
+        # otool -L emits "<path>:" as the first line, then one tab-indented
+        # load command per line.
+        for line in result.stdout.splitlines()[1:]:
+            line = line.strip()
+            if not line:
+                continue
+            load_path = line.split()[0]
+
+            if load_path.startswith("@"):
+                # @loader_path / @rpath / @executable_path — bundled-relative
+                continue
+            if load_path.startswith(("/usr/lib/", "/System/Library/")):
+                # Apple system frameworks — always present, must not bundle
+                continue
+
+            leaked.append(load_path)
+
+        if leaked:
+            raise RuntimeError(
+                f"Verification of bundled {binary.name} failed:\n"
+                "Load commands point outside the bundle / Apple system paths:\n  "
+                + "\n  ".join(leaked)
+                + "\nThese were not rewritten to @loader_path — the wheel will break\n"
+                "on machines without these absolute paths (e.g. without Homebrew)."
+            )
+
+    def _verify_windows_isolation(self, binary: Path, bin_dir: Path) -> None:
+        """Re-run --version with PATH=System32 only.
+
+        Windows DLL search order is: app dir → System32 → SysWOW64 →
+        Windows dir → cwd → PATH.  The binary lives in ``bin_dir``, and
+        we copy bundled DLLs alongside it, so app-dir resolution covers
+        everything we shipped.  Stripping PATH down to ``%SystemRoot%
+        \\System32`` lets the OS DLLs in the SYSTEM_LIBS blocklist
+        resolve while denying anything from MSYS2, the QEMU installer
+        directory, or other PATH entries on the build runner.  A missed
+        DLL therefore produces a non-zero exit.
+        """
+        env = {k: v for k, v in os.environ.items() if not k.startswith(("DYLD_", "LD_LIBRARY"))}
+        system_root = env.get("SystemRoot", r"C:\Windows")
+        env["PATH"] = str(bin_dir) + os.pathsep + str(Path(system_root) / "System32")
+
+        try:
+            result = subprocess.run(
+                [str(binary), "--version"],
+                capture_output=True,
+                text=True,
+                env=env,
+                timeout=30,
+                stdin=subprocess.DEVNULL,
+            )
+        except subprocess.TimeoutExpired as e:
+            raise RuntimeError(
+                f"Isolation verification of {binary.name} timed out (PATH stripped)."
+            ) from e
+
+        if result.returncode != 0:
+            raise RuntimeError(
+                f"Isolation verification of bundled {binary.name} failed:\n"
+                f"  Exit code: {result.returncode}\n"
+                f"  Stderr: {result.stderr}\n"
+                "With PATH=bin_dir;System32 the loader could not find a DLL\n"
+                "the binary needs.  bundle_windows_dlls missed it; the wheel\n"
+                "would break on hosts without it on PATH."
             )
 
     def set_platform_wheel_tag(self, build_data: dict) -> None:

--- a/packages/quicksand-qemu/hatch_build.py
+++ b/packages/quicksand-qemu/hatch_build.py
@@ -864,11 +864,18 @@ class RuntimeBuildHook(BuildHookInterface):
         installer).  On Linux the build is expected to run as root (or
         with passwordless sudo) inside a CI runner container.
         """
+        system = platform.system().lower()
+
         if shutil.which(qemu_name):
             self.app.display_info(f"Found {qemu_name} on PATH")
+            # patchelf is required for Linux library bundling.  When QEMU is
+            # pre-installed on the runner image, the apt step in
+            # _install_qemu_linux is skipped, so patchelf may still be
+            # missing.  Ensure it here.
+            if system == "linux":
+                self._ensure_patchelf_installed()
             return
 
-        system = platform.system().lower()
         self.app.display_info(f"QEMU not found — installing for {system}...")
 
         if system == "darwin":
@@ -879,6 +886,35 @@ class RuntimeBuildHook(BuildHookInterface):
             self._install_qemu_windows()
         else:
             raise RuntimeError(f"Unsupported platform for automatic QEMU install: {system}")
+
+    def _ensure_patchelf_installed(self) -> None:
+        """Install patchelf on Linux if missing.
+
+        patchelf is required by ``BinaryBundler.bundle_linux_libs`` to set
+        RPATH on the bundled QEMU binary; without it, no shared libraries
+        are bundled and the resulting wheel only works on hosts that have
+        every QEMU runtime dep installed system-wide.
+        """
+        if shutil.which("patchelf"):
+            return
+
+        if shutil.which("apt-get"):
+            env = {**dict(os.environ), "DEBIAN_FRONTEND": "noninteractive"}
+            subprocess.run(
+                ["sudo", "apt-get", "install", "-y", "-qq", "patchelf"],
+                check=True,
+                env=env,
+            )
+            self.app.display_info("Installed patchelf via apt")
+        elif shutil.which("dnf"):
+            subprocess.run(["sudo", "dnf", "install", "-y", "patchelf"], check=True)
+            self.app.display_info("Installed patchelf via dnf")
+        else:
+            raise RuntimeError(
+                "patchelf is required for Linux QEMU bundling but is not installed,\n"
+                "and no supported package manager (apt-get, dnf) was found.\n"
+                "Install patchelf manually before building quicksand-qemu."
+            )
 
     def _install_qemu_macos(self) -> None:
         """Install QEMU via Homebrew."""
@@ -902,17 +938,17 @@ class RuntimeBuildHook(BuildHookInterface):
                 env=env,
             )
             subprocess.run(
-                ["sudo", "apt-get", "install", "-y", "-qq", pkg, "qemu-utils"],
+                ["sudo", "apt-get", "install", "-y", "-qq", pkg, "qemu-utils", "patchelf"],
                 check=True,
                 env=env,
             )
-            self.app.display_info(f"Installed {pkg} and qemu-utils via apt")
+            self.app.display_info(f"Installed {pkg}, qemu-utils, and patchelf via apt")
         elif shutil.which("dnf"):
             subprocess.run(
-                ["sudo", "dnf", "install", "-y", "qemu-system-x86-core", "qemu-img"],
+                ["sudo", "dnf", "install", "-y", "qemu-system-x86-core", "qemu-img", "patchelf"],
                 check=True,
             )
-            self.app.display_info("Installed QEMU via dnf")
+            self.app.display_info("Installed QEMU and patchelf via dnf")
         else:
             raise RuntimeError(
                 "No supported package manager found (apt-get or dnf).\n"


### PR DESCRIPTION
## Summary

quicksand-qemu 0.5.8 on PyPI shipped with **zero bundled shared libraries** and **no RPATH** on the QEMU binaries — the wheel only worked on hosts that already had every QEMU runtime dep installed system-wide. A user on fresh WSL Ubuntu hit \`exit code: 127\` from the dynamic linker because \`libnuma\`, \`liburing\`, \`libaio\`, \`libpixman\`, \`libslirp\`, \`libfuse3\`, etc. weren't on their machine and weren't in the wheel either.

Root cause: \`BinaryBundler.bundle_linux_libs\` silently early-returned when \`patchelf\` was missing on the build runner, and \`verify()\` passed anyway because the dynamic linker fell through to \`/etc/ld.so.cache\` and resolved everything against the runner's system libs.

## Changes

- **\`packages/quicksand-qemu/hatch_build.py\`**: install \`patchelf\` alongside \`qemu-system-x86\` in the apt/dnf paths, and add \`_ensure_patchelf_installed\` so runners with QEMU pre-baked still get patchelf.
- **\`bundle_linux_libs\`**: raise instead of warn+return when \`patchelf\` is missing.
- **\`_process_linux_libs\`**: collect every \`ldd\` \"not found\" line and raise with the full list, instead of silently skipping unresolved NEEDED libs.
- **\`verify\`**: on Linux, re-run \`ldd\` against the bundled binary with \`LD_LIBRARY_PATH\` scrubbed and fail the build if any NEEDED entry resolves outside \`bin_dir\` and isn't in the \`SYSTEM_LIBS\` blocklist. This catches the original bug class — bundler missed a lib but verify passed because the build machine had it system-wide.

## Test plan

- [ ] Build quicksand-qemu wheel on a Linux runner that has \`patchelf\` installed; confirm wheel contains all DT_NEEDED libs (excluding glibc/etc.) under \`bin/lib/\` and that \`qemu-system-x86_64\` has RPATH \`\$ORIGIN/lib\`.
- [ ] Build with \`patchelf\` deliberately uninstalled; confirm hard failure with the new error message instead of a wheel ship.
- [ ] Build on a runner missing one of the QEMU runtime deps (e.g. \`libnuma1\`); confirm \`_process_linux_libs\` raises with the list of \"not found\" libs.
- [ ] Install the rebuilt wheel into a clean container/VM with only glibc + the SYSTEM_LIBS blocklist available; confirm \`qemu-system-x86_64 --version\` runs successfully.
- [ ] Confirm 0.5.8's failing scenario (fresh WSL Ubuntu) now boots via the rebuilt wheel without \`apt install\`-ing additional libs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)