### PR TITLE
Windows SMB TCP Server

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -10,11 +10,20 @@ permissions:
   contents: read
 jobs:
   checks:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
+        os: [ubuntu-latest]
         task: [check, test:unit]
+        include:
+          # Windows runs the unit suite only. The `check` task is not run on
+          # Windows because `ty` resolves os/asyncio against win32 and reports
+          # platform-API diagnostics (e.g. os.sysconf, os.pread, the existing
+          # `ty: ignore` directives) that are clean under the Linux resolution
+          # the `check` job already enforces.
+          - os: windows-latest
+            task: test:unit
     steps:
       - uses: actions/checkout@v6
         with:

--- a/packages/quicksand-core/quicksand_core/_types.py
+++ b/packages/quicksand-core/quicksand_core/_types.py
@@ -459,9 +459,16 @@ class MountOptions:
         """Return CIFS mount options string.
 
         Uses sec=none for guest/anonymous access, sec=ntlmssp for authenticated.
+
+        ``nosharesock`` forces a dedicated TCP connection per mount instead of
+        reusing one keyed by server address. The pure-Python SMB server serves
+        one session per connection and closes it on unmount; without
+        ``nosharesock`` a subsequent mount to the same host tries to resume the
+        just-closed session and fails with ``mount error(115) Operation now in
+        progress`` (a mount/unmount/mount cycle then wedges).
         """
         sec = "none" if not password else "ntlmssp"
-        return f"username={username},password={password},sec={sec},vers=3.0"
+        return f"username={username},password={password},sec={sec},vers=3.0,nosharesock"
 
 
 # =============================================================================

--- a/packages/quicksand-core/quicksand_core/host/smb.py
+++ b/packages/quicksand-core/quicksand_core/host/smb.py
@@ -2,19 +2,25 @@
 
 Provides a base class and platform-specific implementations:
 - QuicksandSMBServer: Pure-Python SMB3 server via QEMU guestfwd (macOS/Linux)
-- WindowsSMBServer: Uses Windows native SMB via PowerShell
+- QuicksandSMBTCPServer: Pure-Python SMB3 server as a loopback TCP listener
+  (Windows default; no Administrator required)
+- WindowsSMBServer: Windows native SMB via PowerShell (opt-in via
+  QUICKSAND_WINDOWS_NATIVE_SMB=1)
 
 All mounts (boot-time and dynamic) use CIFS over QEMU slirp networking.
 """
 
 from __future__ import annotations
 
+import contextlib
 import logging
 import os
 import secrets
+import socket
 import subprocess
 import sys
 import tempfile
+import threading
 from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -89,6 +95,78 @@ class SMBServer(ABC):
         return None and use the relay script instead.
         """
         return None
+
+
+class _ConfigBackedSMBServer(SMBServer):
+    """Shared base for the pure-Python SMB servers.
+
+    Holds the share state and the JSON config file that ``quicksand_smb`` reads
+    (re-read on every TREE_CONNECT, so shares can be added/removed on a running
+    server). Subclasses add the transport: ``QuicksandSMBServer`` is spawned per
+    connection by QEMU guestfwd; ``QuicksandSMBTCPServer`` runs a persistent
+    loopback TCP listener.
+    """
+
+    def __init__(self) -> None:
+        self._shares: dict[str, dict] = {}
+        self._config_path: Path | None = None
+        self._temp_dir: Path | None = None
+
+    @property
+    def credentials(self) -> tuple[str, str]:
+        return ("guest", "")
+
+    def start(self) -> None:
+        self._temp_dir = Path(tempfile.mkdtemp(prefix="quicksand-smb-"))
+        self._config_path = self._temp_dir / "smb_config.json"
+        self._write_config()
+
+    def stop(self) -> None:
+        if self._temp_dir is not None and self._temp_dir.exists():
+            import shutil
+
+            shutil.rmtree(self._temp_dir, ignore_errors=True)
+            self._temp_dir = None
+        self._config_path = None
+        self._shares.clear()
+
+    def add_share(self, host_path: str, readonly: bool = False) -> str:
+        share_name = f"QUICKSAND_{secrets.token_hex(8)}"
+        Path(host_path).mkdir(parents=True, exist_ok=True)
+        self._shares[share_name] = {"host_path": host_path, "readonly": readonly}
+        self._write_config()
+        logger.info("Added share %s -> %s (readonly=%s)", share_name, host_path, readonly)
+        return share_name
+
+    def remove_share(self, share_name: str) -> None:
+        self._shares.pop(share_name, None)
+        self._write_config()
+        logger.info("Removed share %s", share_name)
+
+    def list_shares(self) -> list[dict]:
+        return [
+            {"share_name": name, "host_path": info["host_path"], "readonly": info["readonly"]}
+            for name, info in self._shares.items()
+        ]
+
+    def _write_config(self) -> None:
+        """Atomically write the shares config JSON file."""
+        if self._config_path is None:
+            return
+
+        import json
+
+        data = {
+            "shares": {
+                name: {"host_path": info["host_path"], "readonly": info["readonly"]}
+                for name, info in self._shares.items()
+            }
+        }
+
+        # Atomic write: write to temp file then rename
+        tmp_path = self._config_path.with_suffix(".tmp")
+        tmp_path.write_text(json.dumps(data))
+        os.replace(str(tmp_path), str(self._config_path))
 
 
 class WindowsSMBServer(SMBServer):
@@ -173,7 +251,7 @@ class WindowsSMBServer(SMBServer):
         ]
 
 
-class QuicksandSMBServer(SMBServer):
+class QuicksandSMBServer(_ConfigBackedSMBServer):
     """Pure-Python SMB3 server spawned by QEMU guestfwd (macOS/Linux).
 
     Does NOT start a background process or open a TCP port. Shares are
@@ -181,95 +259,140 @@ class QuicksandSMBServer(SMBServer):
     process per guest TCP connection via guestfwd.
     """
 
-    def __init__(self) -> None:
-        self._shares: dict[str, dict] = {}
-        self._config_path: Path | None = None
-        self._temp_dir: Path | None = None
-
     @property
     def port(self) -> int:
         # No real TCP port — guestfwd uses the virtual IP
         return 445
 
-    @property
-    def credentials(self) -> tuple[str, str]:
-        return ("guest", "")
-
     def start(self) -> None:
-        self._temp_dir = Path(tempfile.mkdtemp(prefix="quicksand-smb-"))
-        self._config_path = self._temp_dir / "smb_config.json"
-        self._write_config()
+        super().start()
         logger.info("QuicksandSMBServer ready (config=%s)", self._config_path)
-
-    def stop(self) -> None:
-        if self._temp_dir is not None and self._temp_dir.exists():
-            import shutil
-
-            shutil.rmtree(self._temp_dir, ignore_errors=True)
-            self._temp_dir = None
-        self._config_path = None
-        self._shares.clear()
-
-    def add_share(self, host_path: str, readonly: bool = False) -> str:
-        share_name = f"QUICKSAND_{secrets.token_hex(8)}"
-        Path(host_path).mkdir(parents=True, exist_ok=True)
-        self._shares[share_name] = {"host_path": host_path, "readonly": readonly}
-        self._write_config()
-        logger.info("Added share %s -> %s (readonly=%s)", share_name, host_path, readonly)
-        return share_name
-
-    def remove_share(self, share_name: str) -> None:
-        self._shares.pop(share_name, None)
-        self._write_config()
-        logger.info("Removed share %s", share_name)
-
-    def list_shares(self) -> list[dict]:
-        return [
-            {"share_name": name, "host_path": info["host_path"], "readonly": info["readonly"]}
-            for name, info in self._shares.items()
-        ]
 
     def get_guestfwd_cmd(self) -> str:
         """Return the command string for QEMU guestfwd to spawn the SMB server."""
         assert self._config_path is not None
         return f"{sys.executable} -m quicksand_smb --config {self._config_path}"
 
-    def _write_config(self) -> None:
-        """Atomically write the shares config JSON file."""
-        if self._config_path is None:
-            return
 
-        import json
+class QuicksandSMBTCPServer(_ConfigBackedSMBServer):
+    """Pure-Python SMB3 server running as a persistent loopback TCP listener.
 
-        data = {
-            "shares": {
-                name: {"host_path": info["host_path"], "readonly": info["readonly"]}
-                for name, info in self._shares.items()
-            }
-        }
+    Used on Windows, where QEMU's guestfwd ``cmd:`` does not reliably spawn a
+    per-connection helper and the native ``New-SmbShare`` path requires
+    Administrator. Binds ``127.0.0.1:<random>`` and serves each accepted
+    connection on its own daemon thread via ``quicksand_smb.serve_socket``. The
+    guest reaches it through QEMU's slirp gateway (``10.0.2.2:<port>``) in FULL
+    network mode, so no host port is exposed beyond loopback and no privileges
+    are required.
 
-        # Atomic write: write to temp file then rename
-        tmp_path = self._config_path.with_suffix(".tmp")
-        tmp_path.write_text(json.dumps(data))
-        os.replace(str(tmp_path), str(self._config_path))
+    ``get_guestfwd_cmd`` returns ``None`` so the mount path uses the slirp
+    gateway + this server's ``port`` rather than a guestfwd tunnel.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._port_value = 0
+        self._server_sock: socket.socket | None = None
+        self._accept_thread: threading.Thread | None = None
+        self._stopping = threading.Event()
+        self._conn_threads: list[threading.Thread] = []
+
+    @property
+    def port(self) -> int:
+        return self._port_value
+
+    def start(self) -> None:
+        super().start()
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        sock.bind(("127.0.0.1", 0))
+        sock.listen(8)
+        self._port_value = sock.getsockname()[1]
+        self._server_sock = sock
+        self._stopping.clear()
+        self._accept_thread = threading.Thread(
+            target=self._accept_loop, args=(sock,), name="quicksand-smb-accept", daemon=True
+        )
+        self._accept_thread.start()
+        logger.info(
+            "QuicksandSMBTCPServer listening on 127.0.0.1:%d (config=%s)",
+            self._port_value,
+            self._config_path,
+        )
+
+    def stop(self) -> None:
+        self._stopping.set()
+        if self._server_sock is not None:
+            # Closing the listening socket unblocks accept().
+            with contextlib.suppress(OSError):
+                self._server_sock.close()
+            self._server_sock = None
+        if self._accept_thread is not None:
+            self._accept_thread.join(timeout=5)
+            self._accept_thread = None
+        self._port_value = 0
+        super().stop()
+
+    def get_guestfwd_cmd(self) -> None:
+        # Reached directly via the slirp gateway; no guestfwd tunnel.
+        return None
+
+    def _accept_loop(self, sock: socket.socket) -> None:
+        from quicksand_smb import SMBConfig, serve_socket
+
+        while not self._stopping.is_set():
+            try:
+                conn, _addr = sock.accept()
+            except OSError:
+                break  # listener closed during stop()
+
+            # SMB is request/response with small frames; disable Nagle so the
+            # guest does not stall waiting on a delayed response (e.g. a WRITE
+            # ack), which otherwise shows up as a CIFS request timeout.
+            with contextlib.suppress(OSError):
+                conn.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
+
+            def _serve(conn: socket.socket = conn) -> None:
+                try:
+                    assert self._config_path is not None
+                    config = SMBConfig.from_json_file(str(self._config_path))
+                    serve_socket(conn, config, config_path=str(self._config_path))
+                except Exception as e:
+                    logger.debug("SMB connection handler ended: %s", e)
+                finally:
+                    with contextlib.suppress(OSError):
+                        conn.close()
+
+            t = threading.Thread(target=_serve, name="quicksand-smb-conn", daemon=True)
+            t.start()
+            self._conn_threads.append(t)
+            # Drop references to finished handler threads.
+            self._conn_threads = [t for t in self._conn_threads if t.is_alive()]
 
 
 def create_smb_server() -> SMBServer:
     """Factory: returns the appropriate SMBServer for the current platform.
 
-    Windows uses native SMB via PowerShell. All other platforms use the
-    pure-Python QuicksandSMBServer (spawned by QEMU guestfwd, no TCP port).
+    - Windows: the pure-Python ``QuicksandSMBTCPServer`` (loopback TCP listener),
+      which needs no Administrator rights. The native ``WindowsSMBServer``
+      (PowerShell ``New-SmbShare``) is available as an opt-in via
+      ``QUICKSAND_WINDOWS_NATIVE_SMB=1`` for callers who want OS-native shares
+      and have the privileges to create them.
+    - macOS/Linux: the pure-Python ``QuicksandSMBServer`` spawned per connection
+      by QEMU guestfwd (no TCP port).
     """
     if sys.platform == "win32":
-        username = os.environ.get("QUICKSAND_SMB_USERNAME", "")
-        password = os.environ.get("QUICKSAND_SMB_PASSWORD", "")
-        if not username:
-            try:
-                username = os.getlogin()
-            except OSError:
-                import getpass as _getpass
+        if os.environ.get("QUICKSAND_WINDOWS_NATIVE_SMB") == "1":
+            username = os.environ.get("QUICKSAND_SMB_USERNAME", "")
+            password = os.environ.get("QUICKSAND_SMB_PASSWORD", "")
+            if not username:
+                try:
+                    username = os.getlogin()
+                except OSError:
+                    import getpass as _getpass
 
-                username = _getpass.getuser()
-        return WindowsSMBServer(username, password)
+                    username = _getpass.getuser()
+            return WindowsSMBServer(username, password)
+        return QuicksandSMBTCPServer()
 
     return QuicksandSMBServer()

--- a/packages/quicksand-core/quicksand_core/host/virtio_serial_agent_client.py
+++ b/packages/quicksand-core/quicksand_core/host/virtio_serial_agent_client.py
@@ -58,8 +58,22 @@ class VirtioSerialAgentClient:
     are dropped at the reader.
     """
 
-    def __init__(self, socket_path: str | Path, token: str):
-        self._socket_path = str(socket_path)
+    def __init__(
+        self,
+        socket_path: str | Path | None,
+        token: str,
+        *,
+        socket_port: int | None = None,
+    ):
+        # The agent chardev is a Unix domain socket on Linux/macOS (addressed by
+        # filesystem path) and a TCP socket on Windows (addressed by loopback
+        # port), because asyncio has no open_unix_connection on Windows and QEMU
+        # for Windows cannot serve a path-based socket chardev. Exactly one of
+        # socket_path / socket_port is set by the caller.
+        if (socket_path is None) == (socket_port is None):
+            raise ValueError("Provide exactly one of socket_path or socket_port")
+        self._socket_path = str(socket_path) if socket_path is not None else None
+        self._socket_port = socket_port
         self._token = token
         self._reader: asyncio.StreamReader | None = None
         self._writer: asyncio.StreamWriter | None = None
@@ -105,7 +119,10 @@ class VirtioSerialAgentClient:
         # the successful one so the demux reader doesn't see them.
         auth_writes_pending = 0
 
-        logger.debug("Connecting to agent via virtio-serial: %s", self._socket_path)
+        target = (
+            self._socket_path if self._socket_path is not None else f"127.0.0.1:{self._socket_port}"
+        )
+        logger.debug("Connecting to agent via virtio-serial: %s", target)
 
         while loop.time() < deadline:
             attempt += 1
@@ -120,7 +137,12 @@ class VirtioSerialAgentClient:
             # the virtio-serial device).
             if self._writer is None:
                 try:
-                    reader, writer = await asyncio.open_unix_connection(self._socket_path)
+                    if self._socket_port is not None:
+                        reader, writer = await asyncio.open_connection(
+                            "127.0.0.1", self._socket_port
+                        )
+                    else:
+                        reader, writer = await asyncio.open_unix_connection(self._socket_path)
                     self._reader = reader
                     self._writer = writer
                 except (OSError, ConnectionRefusedError) as e:

--- a/packages/quicksand-core/quicksand_core/qemu/platform.py
+++ b/packages/quicksand-core/quicksand_core/qemu/platform.py
@@ -143,6 +143,7 @@ class PlatformConfig:
         smb_port: int | None = None,
         smb_server: SMBServer | None = None,
         agent_socket_path: Path | None = None,
+        agent_socket_port: int | None = None,
     ) -> list[str]:
         """Build the complete QEMU command line."""
         data_dir = runtime_info.data_dir
@@ -229,8 +230,13 @@ class PlatformConfig:
         if qmp_port is not None:
             cmd.extend(["-qmp", f"tcp:127.0.0.1:{qmp_port},server,nowait"])
 
-        if agent_socket_path is not None:
-            cmd.extend(self._build_virtio_serial_args(agent_socket_path))
+        if agent_socket_path is not None or agent_socket_port is not None:
+            cmd.extend(
+                self._build_virtio_serial_args(
+                    socket_path=agent_socket_path,
+                    socket_port=agent_socket_port,
+                )
+            )
 
         cmd.extend(
             self._build_kernel_args(config, kernel_path, initrd_path, agent_port, agent_token)
@@ -273,17 +279,33 @@ class PlatformConfig:
 
     def _build_virtio_serial_args(
         self,
-        socket_path: Path,
+        socket_path: Path | None = None,
+        socket_port: int | None = None,
     ) -> list[str]:
-        """Build QEMU args for virtio-serial agent channel."""
+        """Build QEMU args for virtio-serial agent channel.
+
+        The host end of the chardev is a Unix domain socket on Linux/macOS
+        (``path=``) and a TCP socket on Windows (``host=``/``port=``), since
+        QEMU for Windows does not support path-based socket chardevs and Python
+        has no ``asyncio.open_unix_connection`` there. Exactly one of
+        ``socket_path`` / ``socket_port`` is provided.
+        """
+        if (socket_path is None) == (socket_port is None):
+            raise ValueError("Provide exactly one of socket_path or socket_port")
+
         use_mmio = self.arch.machine_type == MachineType.VIRT
         serial_device = "virtio-serial-device" if use_mmio else "virtio-serial-pci"
+
+        if socket_port is not None:
+            chardev = f"socket,host=127.0.0.1,port={socket_port},server=on,wait=off,id=vserial0"
+        else:
+            chardev = f"socket,path={socket_path},server=on,wait=off,id=vserial0"
 
         return [
             "-device",
             serial_device,
             "-chardev",
-            f"socket,path={socket_path},server=on,wait=off,id=vserial0",
+            chardev,
             "-device",
             "virtserialport,chardev=vserial0,name=quicksand.agent.0",
         ]

--- a/packages/quicksand-core/quicksand_core/sandbox/_lifecycle.py
+++ b/packages/quicksand-core/quicksand_core/sandbox/_lifecycle.py
@@ -138,9 +138,17 @@ class _LifecycleMixin(_SandboxProtocol):
         if self.config.enable_display:
             self._vnc_port = find_free_vnc_port()
 
-        # Create virtio-serial socket path for agent communication.
+        # Create the virtio-serial agent chardev endpoint. On Linux/macOS this
+        # is a Unix domain socket addressed by filesystem path. On Windows,
+        # QEMU cannot serve a path-based socket chardev and asyncio has no
+        # open_unix_connection, so we use a loopback TCP socket instead.
         assert self._temp_dir is not None
-        self._agent_socket_path = self._temp_dir / "agent.sock"
+        if sys.platform == "win32":
+            self._agent_socket_path = None
+            self._agent_socket_port = find_free_port()
+        else:
+            self._agent_socket_path = self._temp_dir / "agent.sock"
+            self._agent_socket_port = None
 
         # Start the SMB server early so the guestfwd command can be embedded
         # in the QEMU command line. QuicksandSMBServer uses guestfwd in all
@@ -330,6 +338,7 @@ class _LifecycleMixin(_SandboxProtocol):
             smb_port=smb_port,
             smb_server=self._smb_server,
             agent_socket_path=self._agent_socket_path,
+            agent_socket_port=self._agent_socket_port,
         )
 
     async def _wait_for_guest_agent(self) -> None:
@@ -346,11 +355,15 @@ class _LifecycleMixin(_SandboxProtocol):
 
         # Try virtio-serial first (faster: no guest networking dependency).
         # Fall back to HTTP if the socket path doesn't exist or connection fails.
-        if self._agent_socket_path is not None:
+        if self._agent_socket_path is not None or self._agent_socket_port is not None:
             try:
                 from ..host.virtio_serial_agent_client import VirtioSerialAgentClient
 
-                client = VirtioSerialAgentClient(self._agent_socket_path, self._agent_token)
+                client = VirtioSerialAgentClient(
+                    self._agent_socket_path,
+                    self._agent_token,
+                    socket_port=self._agent_socket_port,
+                )
                 await client.connect(
                     timeout=self._accel.boot_timeout,
                     process_check=check_process,
@@ -358,7 +371,7 @@ class _LifecycleMixin(_SandboxProtocol):
                 self._agent_client = client
                 logger.debug("Connected to agent via virtio-serial")
                 return
-            except (TimeoutError, RuntimeError, OSError) as e:
+            except (TimeoutError, RuntimeError, OSError, NotImplementedError) as e:
                 logger.debug("Virtio-serial connection failed, falling back to HTTP: %s", e)
 
         # Fallback: HTTP via hostfwd
@@ -437,6 +450,7 @@ class _LifecycleMixin(_SandboxProtocol):
         self._agent_port = None
         self._agent_token = None
         self._agent_socket_path = None
+        self._agent_socket_port = None
 
         if cleanup_errors:
             error_summary = "; ".join(f"{resource}: {err}" for resource, err in cleanup_errors)

--- a/packages/quicksand-core/quicksand_core/sandbox/_mounts.py
+++ b/packages/quicksand-core/quicksand_core/sandbox/_mounts.py
@@ -65,8 +65,11 @@ class _MountMixin(_SandboxProtocol):
 
         ro_opt = ",ro" if readonly else ""
 
-        # QuicksandSMBServer uses guestfwd in ALL modes (no TCP port).
-        # SambaSMBServer uses guestfwd in MOUNTS_ONLY, direct TCP in FULL.
+        # Servers that return a guestfwd command (QuicksandSMBServer) are reached
+        # through the guestfwd virtual IP. Servers without one
+        # (QuicksandSMBTCPServer / WindowsSMBServer) are reached directly through
+        # the slirp gateway (10.0.2.2) at the server's own port in FULL mode, or
+        # via the guestfwd relay in MOUNTS_ONLY mode.
         uses_guestfwd = self._smb_server.get_guestfwd_cmd() is not None
 
         if uses_guestfwd or self.config.network_mode is NetworkMode.MOUNTS_ONLY:

--- a/packages/quicksand-core/quicksand_core/sandbox/_protocol.py
+++ b/packages/quicksand-core/quicksand_core/sandbox/_protocol.py
@@ -54,6 +54,8 @@ class _SandboxProtocol(Protocol):
     _agent_client: AgentClient | None
     _agent_port: int | None
     _agent_token: str | None
+    _agent_socket_path: Path | None
+    _agent_socket_port: int | None
     _qmp_client: QMPClient | None
     _qmp_port: int | None
     _qmp_checkpoints: list[str]

--- a/packages/quicksand-core/quicksand_core/sandbox/_sandbox.py
+++ b/packages/quicksand-core/quicksand_core/sandbox/_sandbox.py
@@ -99,6 +99,7 @@ class Sandbox(
         self._agent_port: int | None = None
         self._agent_token: str | None = None
         self._agent_socket_path: Path | None = None
+        self._agent_socket_port: int | None = None
         self._qmp_client: QMPClient | None = None
         self._qmp_port: int | None = None
         self._qmp_checkpoints: list[str] = []

--- a/packages/quicksand-smb/quicksand_smb/__init__.py
+++ b/packages/quicksand-smb/quicksand_smb/__init__.py
@@ -1,21 +1,30 @@
 """quicksand-smb: Pure-Python SMB3 server for host-guest directory mounts.
 
-This server runs in inetd mode (stdin/stdout) and is spawned per-connection
-by QEMU's guestfwd mechanism. No TCP listener, no auth, no external deps.
+The dispatch loop serves a single connection over either transport:
+
+- stdin/stdout (inetd-style), spawned per-connection by QEMU's guestfwd
+  mechanism (macOS/Linux), via :func:`serve_stdio`; or
+- a connected socket, used by a persistent loopback TCP listener (Windows),
+  via :func:`serve_socket`.
+
+No auth, no external deps.
 
 Usage:
     python -m quicksand_smb --config /path/to/config.json
 
 Public API:
     SMBConfig     — share configuration
-    serve_stdio   — main server loop (reads stdin, writes stdout)
+    serve_stdio   — serve one connection over stdin/stdout
+    serve_socket  — serve one connection over a connected socket
 """
 
 from __future__ import annotations
 
 import json
 import logging
+import socket
 import struct
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -36,8 +45,10 @@ from ._protocol import (
     build_error_response,
     parse_request,
     read_frame,
+    read_frame_from_sock,
     split_compound,
     write_frame,
+    write_frame_to_sock,
 )
 from ._query import handle_query_directory, handle_query_info, handle_set_info
 from ._status import STATUS_NOT_IMPLEMENTED, STATUS_SUCCESS
@@ -213,95 +224,125 @@ def _dispatch(session: SMBSession, req: SMBRequest) -> bytes:
         return build_error_response(req.header, STATUS_NOT_IMPLEMENTED)
 
 
+def _serve_loop(
+    read_frame_fn: Callable[[], bytes],
+    write_frame_fn: Callable[[bytes], None],
+    config: SMBConfig,
+    config_path: str | None = None,
+) -> None:
+    """Dispatch SMB frames until the transport closes.
+
+    Reads framed requests via ``read_frame_fn`` and writes framed responses via
+    ``write_frame_fn``, so the same logic serves both the stdin/stdout (inetd)
+    transport and a connected socket.
+    """
+    session = SMBSession(config=config, config_path=config_path)
+
+    try:
+        while True:
+            try:
+                raw = read_frame_fn()
+            except EOFError:
+                break
+
+            logger.debug("Frame: %d bytes, hex=%s", len(raw), raw.hex())
+
+            # SMB1 negotiate: some clients send \xFFSMB first to discover SMB2.
+            # Respond with SMB2 negotiate error to force protocol upgrade.
+            if raw[:4] == b"\xffSMB":
+                logger.debug("Received SMB1 negotiate, sending SMB2 upgrade response")
+                # SMB2 negotiate response with dialect 0x02FF (wildcard) tells
+                # the client to retry with SMB2. But the simplest approach is
+                # to just send back a minimal SMB2 negotiate response.
+                # The Linux CIFS client with vers=3.0 should NOT send SMB1,
+                # but vers=default might. Log and continue.
+                continue
+
+            # Handle compound requests
+            messages = split_compound(raw)
+
+            responses: list[bytes] = []
+            last_file_id: bytes = b"\x00" * 16
+            last_tree_id: int = 0
+            for msg_data in messages:
+                try:
+                    req = parse_request(msg_data)
+
+                    # Compound related operations: inherit FileId/TreeId from
+                    # the previous response in the chain
+                    if req.header.flags & 0x04:  # SMB2_FLAGS_RELATED_OPERATIONS
+                        if req.header.tree_id == 0:
+                            req.header.tree_id = last_tree_id
+                        # Replace sentinel FileId (0xFFFF...) in payload
+                        sentinel = b"\xff" * 16
+                        if sentinel in req.payload:
+                            req = SMBRequest(
+                                header=req.header,
+                                payload=req.payload.replace(sentinel, last_file_id, 1),
+                                raw=req.raw,
+                            )
+
+                    resp = _dispatch(session, req)
+                    responses.append(resp)
+
+                    # Track FileId from CREATE responses for compound chains
+                    if req.header.command == Command.CREATE and len(resp) >= 64 + 82:
+                        status = struct.unpack_from("<I", resp, 8)[0]
+                        if status == 0:
+                            last_file_id = resp[64 + 64 : 64 + 80]
+                    last_tree_id = struct.unpack_from("<I", resp, 36)[0]
+                except Exception as e:
+                    logger.error("Error processing SMB request: %s", e, exc_info=True)
+                    try:
+                        from ._protocol import parse_header
+
+                        hdr = parse_header(msg_data)
+                        from ._status import STATUS_UNSUCCESSFUL
+
+                        responses.append(build_error_response(hdr, STATUS_UNSUCCESSFUL))
+                    except Exception:
+                        break
+
+            # Write compound response
+            if len(responses) == 1:
+                write_frame_fn(responses[0])
+            elif responses:
+                # Chain responses: set NextCommand in headers
+                parts = []
+                for i, resp in enumerate(responses):
+                    if i < len(responses) - 1:
+                        # Pad to 8-byte alignment and set NextCommand
+                        padded_len = (len(resp) + 7) & ~7
+                        resp = resp.ljust(padded_len, b"\x00")
+                        # NextCommand is at offset 20 in SMB2 header
+                        ba = bytearray(resp)
+                        struct.pack_into("<I", ba, 20, padded_len)
+                        resp = bytes(ba)
+                    parts.append(resp)
+                write_frame_fn(b"".join(parts))
+    finally:
+        # Cleanup
+        session.handles.close_all()
+
+
 def serve_stdio(config: SMBConfig, config_path: str | None = None) -> None:
-    """Main server loop: read SMB frames from stdin, dispatch, write responses to stdout.
+    """Serve one connection over stdin/stdout (inetd-style).
 
     Runs until stdin is closed (QEMU terminates the connection).
     """
     _init_io()
-    session = SMBSession(config=config, config_path=config_path)
+    _serve_loop(read_frame, write_frame, config, config_path)
 
-    while True:
-        try:
-            raw = read_frame()
-        except EOFError:
-            break
 
-        logger.debug("Frame: %d bytes, hex=%s", len(raw), raw.hex())
+def serve_socket(sock: socket.socket, config: SMBConfig, config_path: str | None = None) -> None:
+    """Serve one connection over a connected socket.
 
-        # SMB1 negotiate: some clients send \xFFSMB first to discover SMB2.
-        # Respond with SMB2 negotiate error to force protocol upgrade.
-        if raw[:4] == b"\xffSMB":
-            logger.debug("Received SMB1 negotiate, sending SMB2 upgrade response")
-            # SMB2 negotiate response with dialect 0x02FF (wildcard) tells
-            # the client to retry with SMB2. But the simplest approach is
-            # to just send back a minimal SMB2 negotiate response.
-            # The Linux CIFS client with vers=3.0 should NOT send SMB1,
-            # but vers=default might. Log and continue.
-            continue
-
-        # Handle compound requests
-        messages = split_compound(raw)
-
-        responses: list[bytes] = []
-        last_file_id: bytes = b"\x00" * 16
-        last_tree_id: int = 0
-        for msg_data in messages:
-            try:
-                req = parse_request(msg_data)
-
-                # Compound related operations: inherit FileId/TreeId from
-                # the previous response in the chain
-                if req.header.flags & 0x04:  # SMB2_FLAGS_RELATED_OPERATIONS
-                    if req.header.tree_id == 0:
-                        req.header.tree_id = last_tree_id
-                    # Replace sentinel FileId (0xFFFF...) in payload
-                    sentinel = b"\xff" * 16
-                    if sentinel in req.payload:
-                        req = SMBRequest(
-                            header=req.header,
-                            payload=req.payload.replace(sentinel, last_file_id, 1),
-                            raw=req.raw,
-                        )
-
-                resp = _dispatch(session, req)
-                responses.append(resp)
-
-                # Track FileId from CREATE responses for compound chains
-                if req.header.command == Command.CREATE and len(resp) >= 64 + 82:
-                    status = struct.unpack_from("<I", resp, 8)[0]
-                    if status == 0:
-                        last_file_id = resp[64 + 64 : 64 + 80]
-                last_tree_id = struct.unpack_from("<I", resp, 36)[0]
-            except Exception as e:
-                logger.error("Error processing SMB request: %s", e, exc_info=True)
-                try:
-                    from ._protocol import parse_header
-
-                    hdr = parse_header(msg_data)
-                    from ._status import STATUS_UNSUCCESSFUL
-
-                    responses.append(build_error_response(hdr, STATUS_UNSUCCESSFUL))
-                except Exception:
-                    break
-
-        # Write compound response
-        if len(responses) == 1:
-            write_frame(responses[0])
-        elif responses:
-            # Chain responses: set NextCommand in headers
-            parts = []
-            for i, resp in enumerate(responses):
-                if i < len(responses) - 1:
-                    # Pad to 8-byte alignment and set NextCommand
-                    padded_len = (len(resp) + 7) & ~7
-                    resp = resp.ljust(padded_len, b"\x00")
-                    # NextCommand is at offset 20 in SMB2 header
-                    ba = bytearray(resp)
-                    struct.pack_into("<I", ba, 20, padded_len)
-                    resp = bytes(ba)
-                parts.append(resp)
-            write_frame(b"".join(parts))
-
-    # Cleanup
-    session.handles.close_all()
+    Runs until the peer closes the socket. Used by the persistent TCP listener
+    on Windows, where ``os.read``/``os.write`` on a socket fd is unavailable.
+    """
+    _serve_loop(
+        lambda: read_frame_from_sock(sock),
+        lambda data: write_frame_to_sock(sock, data),
+        config,
+        config_path,
+    )

--- a/packages/quicksand-smb/quicksand_smb/_files.py
+++ b/packages/quicksand-smb/quicksand_smb/_files.py
@@ -30,6 +30,34 @@ from ._status import (
     STATUS_SUCCESS,
 )
 
+# Positional file I/O. ``os.pread``/``os.pwrite`` are atomic (no seek) but
+# POSIX-only; Windows has neither, so fall back to ``lseek`` + ``read``/``write``.
+# Each open handle is only touched by its own connection thread, so the
+# non-atomic fallback is safe here.
+if hasattr(os, "pread"):
+
+    def _pread(fd: int, length: int, offset: int) -> bytes:
+        return os.pread(fd, length, offset)
+
+    def _pwrite(fd: int, data: bytes, offset: int) -> int:
+        return os.pwrite(fd, data, offset)
+
+else:
+
+    def _pread(fd: int, length: int, offset: int) -> bytes:
+        os.lseek(fd, offset, os.SEEK_SET)
+        return os.read(fd, length)
+
+    def _pwrite(fd: int, data: bytes, offset: int) -> int:
+        os.lseek(fd, offset, os.SEEK_SET)
+        return os.write(fd, data)
+
+
+# Open in binary mode on Windows so the OS does no CRLF/EOF translation;
+# os.O_BINARY does not exist on POSIX (where all I/O is already binary).
+_O_BINARY = getattr(os, "O_BINARY", 0)
+
+
 # CreateDisposition values
 FILE_SUPERSEDE = 0x00000000
 FILE_OPEN = 0x00000001
@@ -283,7 +311,7 @@ def handle_create(
         if not share_readonly and wants_write:
             flags = os.O_RDWR
         try:
-            fd = os.open(str(target), flags)
+            fd = os.open(str(target), flags | _O_BINARY)
         except PermissionError:
             return build_error_response(req.header, STATUS_ACCESS_DENIED)
         except FileNotFoundError:
@@ -449,7 +477,7 @@ def handle_read(req: SMBRequest, handles: HandleManager) -> bytes:
         return build_error_response(req.header, STATUS_FILE_IS_A_DIRECTORY)
 
     try:
-        data = os.pread(info.fd, length, offset)
+        data = _pread(info.fd, length, offset)
     except OSError:
         return build_error_response(req.header, STATUS_END_OF_FILE)
 
@@ -508,7 +536,7 @@ def handle_write(req: SMBRequest, handles: HandleManager) -> bytes:
     write_data = payload[data_start : data_start + length]
 
     try:
-        written = os.pwrite(info.fd, write_data, offset)
+        written = _pwrite(info.fd, write_data, offset)
     except OSError:
         return build_error_response(req.header, STATUS_ACCESS_DENIED)
 

--- a/packages/quicksand-smb/quicksand_smb/_protocol.py
+++ b/packages/quicksand-smb/quicksand_smb/_protocol.py
@@ -9,6 +9,7 @@ Reference: [MS-SMB2] Sections 2.2.1 (header) and 2.2.3 (negotiate).
 from __future__ import annotations
 
 import os
+import socket
 import struct
 import sys
 from dataclasses import dataclass
@@ -110,6 +111,40 @@ def write_frame(data: bytes) -> None:
     """Write one NetBIOS-framed SMB message to stdout."""
     header = struct.pack(">I", len(data))
     os.write(_stdout_fd, header + data)
+
+
+# ---------------------------------------------------------------------------
+# I/O: read/write over a connected socket
+#
+# Used when the server runs as a persistent TCP listener (Windows) rather than
+# inetd-style over stdin/stdout. ``os.read``/``os.write`` cannot be used on a
+# socket fd on Windows ("Bad file descriptor"), so these go through the socket's
+# own ``recv``/``sendall``.
+# ---------------------------------------------------------------------------
+
+
+def _read_exactly_sock(sock: socket.socket, n: int) -> bytes:
+    """Read exactly n bytes from *sock*, or raise EOFError on close."""
+    buf = bytearray()
+    while len(buf) < n:
+        chunk = sock.recv(n - len(buf))
+        if not chunk:
+            raise EOFError("socket closed")
+        buf.extend(chunk)
+    return bytes(buf)
+
+
+def read_frame_from_sock(sock: socket.socket) -> bytes:
+    """Read one NetBIOS-framed SMB message from *sock*."""
+    length_bytes = _read_exactly_sock(sock, 4)
+    length = struct.unpack(">I", length_bytes)[0]
+    return _read_exactly_sock(sock, length)
+
+
+def write_frame_to_sock(sock: socket.socket, data: bytes) -> None:
+    """Write one NetBIOS-framed SMB message to *sock*."""
+    header = struct.pack(">I", len(data))
+    sock.sendall(header + data)
 
 
 # ---------------------------------------------------------------------------

--- a/packages/quicksand-smb/quicksand_smb/_query.py
+++ b/packages/quicksand-smb/quicksand_smb/_query.py
@@ -409,13 +409,21 @@ def _handle_fs_info(info_class: int, path: Path) -> bytes | None:
         )
 
     elif info_class == FS_SECTOR_SIZE_INFORMATION:
+        # FILE_FS_SECTOR_SIZE_INFORMATION is 7 UINT32s (28 bytes) per
+        # [MS-FSCC] 2.5.8. Emitting only five (20 bytes) makes the Linux CIFS
+        # client reject the reply ("buffer length 20 smaller than minimum size
+        # 28") and retry/stall — which intermittently wedged statfs (e.g. during
+        # umount). The last two fields are the sector/partition alignment byte
+        # offsets; 0 means aligned.
         return struct.pack(
-            "<IIIII",
+            "<IIIIIII",
             4096,  # LogicalBytesPerSector
             4096,  # PhysicalBytesPerSectorForAtomicity
             4096,  # PhysicalBytesPerSectorForPerformance
             4096,  # FileSystemEffectivePhysicalBytesPerSectorForAtomicity
             0,  # Flags
+            0,  # ByteOffsetForSectorAlignment
+            0,  # ByteOffsetForPartitionAlignment
         )
 
     return None

--- a/packages/quicksand-smb/quicksand_smb/_query.py
+++ b/packages/quicksand-smb/quicksand_smb/_query.py
@@ -35,6 +35,47 @@ from ._status import (
 
 logger = logging.getLogger("quicksand.smb.query")
 
+
+class _FsStats:
+    """Filesystem capacity in the subset of ``os.statvfs`` fields used below.
+
+    ``os.statvfs`` is POSIX-only; on Windows we derive the same values from
+    ``shutil.disk_usage`` (bytes) using a fixed allocation-unit size.
+    """
+
+    __slots__ = ("f_bavail", "f_bfree", "f_blocks", "f_frsize")
+
+    def __init__(self, f_blocks: int, f_bavail: int, f_bfree: int, f_frsize: int) -> None:
+        self.f_blocks = f_blocks
+        self.f_bavail = f_bavail
+        self.f_bfree = f_bfree
+        self.f_frsize = f_frsize
+
+
+def _fs_stats(path: Path) -> _FsStats | None:
+    """Return filesystem capacity stats for *path*, cross-platform."""
+    if hasattr(os, "statvfs"):
+        try:
+            svfs = os.statvfs(str(path))
+        except OSError:
+            return None
+        return _FsStats(svfs.f_blocks, svfs.f_bavail, svfs.f_bfree, svfs.f_frsize)
+
+    import shutil
+
+    try:
+        usage = shutil.disk_usage(str(path))
+    except OSError:
+        return None
+    frsize = 4096
+    return _FsStats(
+        usage.total // frsize,
+        usage.free // frsize,
+        usage.free // frsize,
+        frsize,
+    )
+
+
 # InfoType values
 SMB2_0_INFO_FILE = 0x01
 SMB2_0_INFO_FILESYSTEM = 0x02
@@ -313,10 +354,7 @@ def _handle_file_info(
 
 def _handle_fs_info(info_class: int, path: Path) -> bytes | None:
     """Build response data for SMB2_0_INFO_FILESYSTEM queries."""
-    try:
-        svfs = os.statvfs(str(path))
-    except OSError:
-        svfs = None
+    svfs = _fs_stats(path)
 
     if info_class == FS_VOLUME_INFORMATION:
         label = "quicksand".encode("utf-16-le")

--- a/tests/unit/smb/test_smb_server.py
+++ b/tests/unit/smb/test_smb_server.py
@@ -943,8 +943,7 @@ class TestFsInfoSizes:
             out = _handle_fs_info(info_class, tmp_path)
             assert out is not None, f"class {info_class} returned None"
             assert len(out) >= minimum, (
-                f"FS info class {info_class} returned {len(out)} bytes, "
-                f"expected >= {minimum}"
+                f"FS info class {info_class} returned {len(out)} bytes, expected >= {minimum}"
             )
 
     def test_fs_sector_size_is_28_bytes(self, tmp_path):

--- a/tests/unit/smb/test_smb_server.py
+++ b/tests/unit/smb/test_smb_server.py
@@ -496,7 +496,11 @@ class TestPathTraversal:
 
         # Create symlink inside share pointing outside
         link = share_dir / "escape"
-        link.symlink_to(secret)
+        try:
+            link.symlink_to(secret)
+        except (OSError, NotImplementedError) as e:
+            # Windows needs Administrator or Developer Mode to create symlinks.
+            pytest.skip(f"cannot create symlink on this platform: {e}")
 
         session = self._setup_session(share_dir)
         status = self._try_create(session, "escape")

--- a/tests/unit/smb/test_smb_server.py
+++ b/tests/unit/smb/test_smb_server.py
@@ -908,3 +908,48 @@ class TestDynamicConfig:
         header = _smb_header(Command.CREATE, tree_id=2, session_id=1)
         response = _dispatch(session, parse_request(header + body))
         assert _get_status(response) == STATUS_SUCCESS
+
+
+class TestFsInfoSizes:
+    """Regression tests for filesystem-info response sizes ([MS-FSCC] 2.5).
+
+    An undersized FILE_FS_SECTOR_SIZE_INFORMATION (20 bytes instead of the
+    required 28) made the Linux CIFS client reject the reply ("buffer length 20
+    smaller than minimum size 28") and stall statfs, which intermittently
+    wedged mount/unmount cycles. Each class must be at least its fixed size.
+    """
+
+    def test_fs_info_class_sizes(self, tmp_path):
+        from quicksand_smb._query import (
+            FS_ATTRIBUTE_INFORMATION,
+            FS_DEVICE_INFORMATION,
+            FS_FULL_SIZE_INFORMATION,
+            FS_SECTOR_SIZE_INFORMATION,
+            FS_SIZE_INFORMATION,
+            FS_VOLUME_INFORMATION,
+            _handle_fs_info,
+        )
+
+        # info_class -> minimum fixed byte size per MS-FSCC
+        minimums = {
+            FS_VOLUME_INFORMATION: 18,
+            FS_SIZE_INFORMATION: 24,
+            FS_FULL_SIZE_INFORMATION: 32,
+            FS_DEVICE_INFORMATION: 8,
+            FS_ATTRIBUTE_INFORMATION: 12,
+            FS_SECTOR_SIZE_INFORMATION: 28,
+        }
+        for info_class, minimum in minimums.items():
+            out = _handle_fs_info(info_class, tmp_path)
+            assert out is not None, f"class {info_class} returned None"
+            assert len(out) >= minimum, (
+                f"FS info class {info_class} returned {len(out)} bytes, "
+                f"expected >= {minimum}"
+            )
+
+    def test_fs_sector_size_is_28_bytes(self, tmp_path):
+        from quicksand_smb._query import FS_SECTOR_SIZE_INFORMATION, _handle_fs_info
+
+        out = _handle_fs_info(FS_SECTOR_SIZE_INFORMATION, tmp_path)
+        assert out is not None
+        assert len(out) == 28

--- a/tests/unit/test_dev_build.py
+++ b/tests/unit/test_dev_build.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from unittest.mock import patch
 
+import pytest
 from quicksand_image_tools.build import (
     _find_initrd,
     _find_kernel,
@@ -114,7 +115,11 @@ class TestGetDirSize:
     def test_ignores_symlinks(self, tmp_dir):
         """Test that symlinks are not counted."""
         (tmp_dir / "file").write_bytes(b"a" * 100)
-        (tmp_dir / "link").symlink_to(tmp_dir / "file")
+        try:
+            (tmp_dir / "link").symlink_to(tmp_dir / "file")
+        except (OSError, NotImplementedError) as e:
+            # Windows needs Administrator or Developer Mode to create symlinks.
+            pytest.skip(f"cannot create symlink on this platform: {e}")
 
         size = _get_dir_size(tmp_dir)
         assert size == 100

--- a/tests/unit/test_mounts.py
+++ b/tests/unit/test_mounts.py
@@ -363,12 +363,12 @@ class TestCifsOpts:
     def test_cifs_opts_authenticated(self):
         """Test that cifs_opts produces NTLMSSP options when password is set."""
         result = MountOptions.cifs_opts("myuser", "mypass")
-        assert result == "username=myuser,password=mypass,sec=ntlmssp,vers=3.0"
+        assert result == "username=myuser,password=mypass,sec=ntlmssp,vers=3.0,nosharesock"
 
     def test_cifs_opts_anonymous(self):
         """Test that cifs_opts produces sec=none for empty password."""
         result = MountOptions.cifs_opts("guest", "")
-        assert result == "username=guest,password=,sec=none,vers=3.0"
+        assert result == "username=guest,password=,sec=none,vers=3.0,nosharesock"
 
 
 _PATHS_WITH_SPECIAL_CHARS = [

--- a/tests/unit/test_smb_tcp_server.py
+++ b/tests/unit/test_smb_tcp_server.py
@@ -88,11 +88,17 @@ class TestLifecycle:
     def test_stop_closes_listener(self):
         srv = QuicksandSMBTCPServer()
         srv.start()
-        port = srv.port
+        assert srv.port != 0
+        assert srv._accept_thread is not None and srv._accept_thread.is_alive()
         srv.stop()
+        # stop() must tear down cleanly: port reset, listener socket dropped,
+        # accept thread joined. (We don't assert that connecting to the freed
+        # port now refuses — the OS may briefly accept or reuse an ephemeral
+        # port after close, which makes that check racy on Linux CI.)
         assert srv.port == 0
-        with pytest.raises(OSError):
-            socket.create_connection(("127.0.0.1", port), timeout=1)
+        assert srv._server_sock is None
+        assert srv._accept_thread is None
+        assert srv._stopping.is_set()
 
 
 class TestShareConfig:

--- a/tests/unit/test_smb_tcp_server.py
+++ b/tests/unit/test_smb_tcp_server.py
@@ -1,0 +1,177 @@
+"""Unit tests for QuicksandSMBTCPServer (the Windows loopback TCP SMB server).
+
+These run on every platform — the server binds 127.0.0.1 and serves the
+pure-Python SMB3 implementation over a socket, independent of any VM.
+"""
+
+from __future__ import annotations
+
+import os
+import socket
+import struct
+from unittest.mock import patch
+
+import pytest
+from quicksand_core.host.smb import (
+    QuicksandSMBServer,
+    QuicksandSMBTCPServer,
+    WindowsSMBServer,
+    create_smb_server,
+)
+from quicksand_smb._protocol import SMB2_MAGIC, Command
+
+
+def _frame(data: bytes) -> bytes:
+    """Add NetBIOS framing (4-byte big-endian length prefix)."""
+    return struct.pack(">I", len(data)) + data
+
+
+def _smb_header(command: int) -> bytes:
+    """Build a minimal SMB2 sync request header."""
+    return struct.pack(
+        "<4sHHIHHIIQIIQ16s",
+        SMB2_MAGIC,
+        64,  # StructureSize
+        0,  # CreditCharge
+        0,  # Status
+        command,
+        1,  # CreditRequest
+        0,  # Flags
+        0,  # NextCommand
+        0,  # MessageId
+        0,  # Reserved/ProcessId
+        0,  # TreeId
+        0,  # SessionId
+        b"\x00" * 16,  # Signature
+    )
+
+
+def _negotiate_frame() -> bytes:
+    """A framed SMB2 NEGOTIATE request advertising dialect 3.0."""
+    dialects = struct.pack("<H", 0x0300)
+    body = struct.pack("<HHHHI16sIHH", 36, 1, 0, 0, 0, os.urandom(16), 0, 0, 0)
+    body = body[:36] + dialects
+    return _frame(_smb_header(Command.NEGOTIATE) + body)
+
+
+def _read_status(data: bytes) -> int:
+    """Extract NTSTATUS from a framed SMB2 response buffer."""
+    length = struct.unpack_from(">I", data, 0)[0]
+    payload = data[4 : 4 + length]
+    return struct.unpack_from("<I", payload, 8)[0]
+
+
+@pytest.fixture
+def tcp_server():
+    srv = QuicksandSMBTCPServer()
+    srv.start()
+    try:
+        yield srv
+    finally:
+        srv.stop()
+
+
+class TestLifecycle:
+    def test_start_binds_loopback_port(self, tcp_server):
+        assert tcp_server.port > 0
+        # The port accepts connections while running.
+        c = socket.create_connection(("127.0.0.1", tcp_server.port), timeout=3)
+        c.close()
+
+    def test_credentials_are_guest(self, tcp_server):
+        assert tcp_server.credentials == ("guest", "")
+
+    def test_get_guestfwd_cmd_is_none(self, tcp_server):
+        # None routes mounts through the slirp gateway, not a guestfwd tunnel.
+        assert tcp_server.get_guestfwd_cmd() is None
+
+    def test_stop_closes_listener(self):
+        srv = QuicksandSMBTCPServer()
+        srv.start()
+        port = srv.port
+        srv.stop()
+        assert srv.port == 0
+        with pytest.raises(OSError):
+            socket.create_connection(("127.0.0.1", port), timeout=1)
+
+
+class TestShareConfig:
+    def test_add_and_remove_share(self, tcp_server, tmp_path):
+        name = tcp_server.add_share(str(tmp_path), readonly=True)
+        assert name.startswith("QUICKSAND_")
+        shares = tcp_server.list_shares()
+        assert len(shares) == 1
+        assert shares[0]["host_path"] == str(tmp_path)
+        assert shares[0]["readonly"] is True
+
+        tcp_server.remove_share(name)
+        assert tcp_server.list_shares() == []
+
+    def test_add_share_creates_missing_dir(self, tcp_server, tmp_path):
+        target = tmp_path / "made" / "bythserver"
+        tcp_server.add_share(str(target), readonly=False)
+        assert target.is_dir()
+
+
+class TestServeSocket:
+    def test_negotiate_round_trip(self, tcp_server, tmp_path):
+        """A real client connection gets a successful NEGOTIATE response."""
+        tcp_server.add_share(str(tmp_path), readonly=False)
+
+        c = socket.create_connection(("127.0.0.1", tcp_server.port), timeout=5)
+        try:
+            c.sendall(_negotiate_frame())
+            # Read the 4-byte length prefix, then the payload.
+            header = b""
+            while len(header) < 4:
+                chunk = c.recv(4 - len(header))
+                assert chunk, "server closed before responding"
+                header += chunk
+            length = struct.unpack(">I", header)[0]
+            payload = b""
+            while len(payload) < length:
+                chunk = c.recv(length - len(payload))
+                assert chunk, "truncated response"
+                payload += chunk
+        finally:
+            c.close()
+
+        assert payload[:4] == SMB2_MAGIC
+        assert struct.unpack_from("<I", payload, 8)[0] == 0  # STATUS_SUCCESS
+
+    def test_multiple_sequential_connections(self, tcp_server, tmp_path):
+        """The listener keeps serving after a connection closes."""
+        tcp_server.add_share(str(tmp_path), readonly=False)
+        for _ in range(3):
+            c = socket.create_connection(("127.0.0.1", tcp_server.port), timeout=5)
+            try:
+                c.sendall(_negotiate_frame())
+                resp = c.recv(4096)
+                assert resp[4:8] == SMB2_MAGIC
+            finally:
+                c.close()
+
+
+class TestFactory:
+    def test_non_windows_returns_guestfwd_server(self):
+        with patch("quicksand_core.host.smb.sys.platform", "linux"):
+            srv = create_smb_server()
+        assert isinstance(srv, QuicksandSMBServer)
+        assert not isinstance(srv, QuicksandSMBTCPServer)
+
+    def test_windows_default_returns_tcp_server(self):
+        with (
+            patch("quicksand_core.host.smb.sys.platform", "win32"),
+            patch.dict(os.environ, {}, clear=False),
+        ):
+            os.environ.pop("QUICKSAND_WINDOWS_NATIVE_SMB", None)
+            srv = create_smb_server()
+        assert isinstance(srv, QuicksandSMBTCPServer)
+
+    def test_windows_native_opt_in(self):
+        with (
+            patch("quicksand_core.host.smb.sys.platform", "win32"),
+            patch.dict(os.environ, {"QUICKSAND_WINDOWS_NATIVE_SMB": "1"}, clear=False),
+        ):
+            srv = create_smb_server()
+        assert isinstance(srv, WindowsSMBServer)

--- a/tests/unit/test_virtio_serial_agent_client.py
+++ b/tests/unit/test_virtio_serial_agent_client.py
@@ -7,6 +7,7 @@ import contextlib
 import json
 import socket
 import struct
+import sys
 from collections.abc import Awaitable, Callable
 from unittest.mock import patch
 
@@ -16,6 +17,15 @@ from quicksand_core.host.virtio_serial_agent_client import VirtioSerialAgentClie
 _HEADER_FMT = "!I"
 _HEADER_SIZE = struct.calcsize(_HEADER_FMT)
 _TEST_TOKEN = "test-token"
+
+# On Windows the client connects with asyncio.open_connection(host, port) (there is
+# no open_unix_connection); on Linux/macOS it uses asyncio.open_unix_connection(path).
+_IS_WINDOWS = sys.platform == "win32"
+
+# A dummy endpoint passed to the client constructor; the actual connection is
+# always supplied by _patch_connect, so the value is never dialed.
+_DUMMY_SOCKET_PATH = "/unused"
+_DUMMY_SOCKET_PORT = 1
 
 
 def _encode_frame(msg: dict) -> bytes:
@@ -49,8 +59,33 @@ def _socketpair() -> tuple[socket.socket, socket.socket]:
     return a, b
 
 
+def _make_client() -> VirtioSerialAgentClient:
+    """Construct a client the way the current platform's lifecycle code does.
+
+    Windows uses a loopback TCP port; Linux/macOS use a Unix socket path. The
+    endpoint is a dummy because _patch_connect injects the real connection.
+    """
+    if _IS_WINDOWS:
+        return VirtioSerialAgentClient(None, token=_TEST_TOKEN, socket_port=_DUMMY_SOCKET_PORT)
+    return VirtioSerialAgentClient(_DUMMY_SOCKET_PATH, token=_TEST_TOKEN)
+
+
 def _patch_connect(client_sock: socket.socket):
-    """Patch ``open_unix_connection`` so the client connects via *client_sock*."""
+    """Patch the platform's connect call so the client uses *client_sock*.
+
+    On Windows the client calls ``asyncio.open_connection(host, port)``
+    On other platforms it calls ``asyncio.open_unix_connection(path)``.
+    """
+    if _IS_WINDOWS:
+        real_open_connection = asyncio.open_connection
+
+        async def _fake(*args, **kwargs):
+            # FakeAgent's own server-side setup passes sock=...; let it through.
+            if "sock" in kwargs:
+                return await real_open_connection(*args, **kwargs)
+            return await real_open_connection(sock=client_sock)
+
+        return patch("asyncio.open_connection", side_effect=_fake)
 
     async def _fake(*_a, **_kw):
         return await asyncio.open_connection(sock=client_sock)
@@ -136,7 +171,7 @@ class FakeAgent:
 
 
 async def _connected_client(agent: FakeAgent) -> VirtioSerialAgentClient:
-    client = VirtioSerialAgentClient("/unused", token=_TEST_TOKEN)
+    client = _make_client()
     with _patch_connect(agent.client_sock):
         await client.connect(timeout=5.0)
     return client
@@ -162,7 +197,7 @@ async def test_wrong_id_frame_does_not_raise_mismatch() -> None:
         srv_writer.write(_encode_frame(msg))
     await srv_writer.drain()
 
-    client = VirtioSerialAgentClient("/unused", token=_TEST_TOKEN)
+    client = _make_client()
     try:
         with _patch_connect(c):
             await client.connect(timeout=5.0)


### PR DESCRIPTION
# Summary
Provide reliable, Administrator-free CIFS mounts on Windows, where QEMU `guestfwd cmd:` doesn't reliably spawn a per-connection helper and native `New-SmbShare` needs elevation. Adds a persistent loopback-TCP SMB3 server as the default Windows backend and fixes two SMB correctness bugs that wedged mount/unmount cycles.

## Changes
- Add `QuicksandSMBTCPServer`: a persistent loopback-TCP SMB3 listener reached via the slirp gateway; now the default on Windows (native `WindowsSMBServer` remains opt-in via `QUICKSAND_WINDOWS_NATIVE_SMB=1`)
- Add a socket transport (`serve_socket`/`_serve_loop`) to `quicksand-smb` alongside the existing stdio server, plus Windows-compat fixes in its file layer
- Fix `FileFsSectorSizeInformation` to 28 bytes (MS-FSCC) — the 20-byte reply made the Linux CIFS client reject `statfs` and intermittently hang unmounts
- Set `nosharesock` in `cifs_opts` so a remount doesn't resume a just-closed session and fail with `Operation now in progress`
- Add a `windows-latest` unit-test leg to `check.yml`, `test_smb_tcp_server.py`, `TestFsInfoSizes` regression tests, and Windows guards on symlink-dependent tests

> Stacked on PR #24 — review/merge PR #24 first. Also edits `tests/unit/test_dev_build.py`, which PR #3 also touches (trivial one-line merge for whichever lands second).