### PR TITLE
Fix SMB rename path confinement

### DIFF
--- a/packages/quicksand-smb/quicksand_smb/__init__.py
+++ b/packages/quicksand-smb/quicksand_smb/__init__.py
@@ -203,7 +203,7 @@ def _dispatch(session: SMBSession, req: SMBRequest) -> bytes:
         return handle_query_info(req, session.handles, session.shares_dict, session.tree_map)
 
     elif cmd == Command.SET_INFO:
-        return handle_set_info(req, session.handles)
+        return handle_set_info(req, session.handles, session.shares_dict, session.tree_map)
 
     elif cmd == Command.QUERY_DIRECTORY:
         return handle_query_directory(req, session.handles, session.shares_dict, session.tree_map)

--- a/packages/quicksand-smb/quicksand_smb/_query.py
+++ b/packages/quicksand-smb/quicksand_smb/_query.py
@@ -7,6 +7,7 @@ Reference: [MS-SMB2] Sections 2.2.37-2.2.42 and [MS-FSCC].
 
 from __future__ import annotations
 
+import contextlib
 import logging
 import os
 import struct
@@ -823,14 +824,38 @@ def _handle_set_file_info(
         if new_path is None:
             return STATUS_ACCESS_DENIED
 
+        old_path = info.path
+        reopen_path = None
         try:
             if new_path.exists() and not replace_if_exists:
                 from ._status import STATUS_OBJECT_NAME_COLLISION
 
                 return STATUS_OBJECT_NAME_COLLISION
-            os.rename(str(info.path), str(new_path))
+
+            if info.fd >= 0:
+                os.close(info.fd)
+                info.fd = -1
+
+            os.rename(str(old_path), str(new_path))
             info.path = new_path
+
+            if not info.is_dir:
+                flags = os.O_RDONLY if info.readonly else os.O_RDWR
+                reopen_path = str(new_path)
+                info.fd = os.open(reopen_path, flags | getattr(os, "_O_BINARY", 0))
         except OSError:
+            if reopen_path:
+                with contextlib.suppress(OSError):
+                    os.close(info.fd)
+                info.fd = -1
+            if info.fd == -1 and not info.is_dir and old_path.exists():
+                try:
+                    info.fd = os.open(
+                        str(old_path),
+                        (os.O_RDONLY if info.readonly else os.O_RDWR) | getattr(os, "_O_BINARY", 0),
+                    )
+                except OSError:
+                    info.fd = -1
             return STATUS_ACCESS_DENIED
         return STATUS_SUCCESS
 

--- a/packages/quicksand-smb/quicksand_smb/_query.py
+++ b/packages/quicksand-smb/quicksand_smb/_query.py
@@ -19,6 +19,7 @@ from ._files import (
     HandleManager,
     _filetime,
     _filetime_now,
+    _resolve_path,
 )
 from ._protocol import SMBRequest, build_error_response, build_response_header
 from ._status import (
@@ -700,6 +701,8 @@ def handle_query_directory(
 def handle_set_info(
     req: SMBRequest,
     handles: HandleManager,
+    shares: dict[str, dict],
+    tree_map: dict[int, str],
 ) -> bytes:
     """Handle SET_INFO request."""
     payload = req.payload
@@ -718,6 +721,11 @@ def handle_set_info(
     if info is None:
         return build_error_response(req.header, STATUS_INVALID_HANDLE)
 
+    share_name = tree_map.get(info.tree_id)
+    share_root = (
+        Path(shares[share_name]["host_path"]) if share_name and share_name in shares else None
+    )
+
     # Extract the input buffer
     buf_start = buffer_offset - 64
     if buf_start < 0:
@@ -725,7 +733,7 @@ def handle_set_info(
     buffer_data = payload[buf_start : buf_start + buffer_length]
 
     if info_type == SMB2_0_INFO_FILE:
-        result = _handle_set_file_info(file_info_class, buffer_data, info)
+        result = _handle_set_file_info(file_info_class, buffer_data, info, share_root)
     else:
         result = STATUS_NOT_SUPPORTED
 
@@ -742,6 +750,7 @@ def _handle_set_file_info(
     info_class: int,
     data: bytes,
     info: HandleInfo,
+    share_root: Path | None,
 ) -> int:
     """Apply SET_INFO for file info classes. Returns NTSTATUS."""
     if info.readonly:
@@ -796,12 +805,23 @@ def _handle_set_file_info(
         if len(data) < 20:
             return STATUS_INVALID_PARAMETER
         replace_if_exists = struct.unpack_from("<B", data)[0]
+        root_directory = struct.unpack_from("<Q", data, 8)[0]
         name_length = struct.unpack_from("<I", data, 16)[0]
+        if root_directory != 0 or name_length == 0 or name_length % 2:
+            return STATUS_INVALID_PARAMETER
+        if name_length > len(data) - 20:
+            return STATUS_INVALID_PARAMETER
         name_bytes = data[20 : 20 + name_length]
-        new_name = name_bytes.decode("utf-16-le", errors="replace")
-        # The name might be a full path like \newname or just newname
-        new_name = new_name.lstrip("\\").replace("\\", "/")
-        new_path = info.path.parent / new_name
+        try:
+            new_name = name_bytes.decode("utf-16-le")
+        except UnicodeDecodeError:
+            return STATUS_INVALID_PARAMETER
+        if share_root is None:
+            return STATUS_ACCESS_DENIED
+
+        new_path = _resolve_path(share_root, new_name)
+        if new_path is None:
+            return STATUS_ACCESS_DENIED
 
         try:
             if new_path.exists() and not replace_if_exists:

--- a/tests/unit/smb/test_smb_server.py
+++ b/tests/unit/smb/test_smb_server.py
@@ -38,6 +38,7 @@ from quicksand_smb._status import (
     STATUS_BAD_NETWORK_NAME,
     STATUS_END_OF_FILE,
     STATUS_INVALID_HANDLE,
+    STATUS_INVALID_PARAMETER,
     STATUS_NO_MORE_FILES,
     STATUS_OBJECT_NAME_COLLISION,
     STATUS_OBJECT_NAME_NOT_FOUND,
@@ -471,6 +472,65 @@ class TestPathTraversal:
         response = _dispatch(session, req)
         return _get_status(response)
 
+    def _open_file(self, session: SMBSession, filename: str) -> bytes:
+        name_bytes = filename.encode("utf-16-le")
+        body = struct.pack(
+            "<HBBIqQIIIIIHHII",
+            57,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0x12019F,
+            0x80,
+            0x07,
+            0x01,
+            0,
+            64 + 56,
+            len(name_bytes),
+            0,
+            0,
+        )
+        body += name_bytes
+        header = _smb_header(Command.CREATE, tree_id=1, session_id=1)
+        response = _dispatch(session, parse_request(header + body))
+        assert _get_status(response) == STATUS_SUCCESS
+        return response[64 + 64 : 64 + 80]
+
+    def _try_rename(
+        self,
+        session: SMBSession,
+        file_id: bytes,
+        new_name: str,
+        *,
+        replace_if_exists: bool = False,
+        root_directory: int = 0,
+    ) -> int:
+        name_bytes = new_name.encode("utf-16-le")
+        rename_info = struct.pack(
+            "<B7xQI",
+            replace_if_exists,
+            root_directory,
+            len(name_bytes),
+        )
+        rename_info += name_bytes
+        body = struct.pack(
+            "<HBBIHHI16s",
+            33,
+            0x01,
+            10,
+            len(rename_info),
+            64 + 32,
+            0,
+            0,
+            file_id,
+        )
+        body += rename_info
+        header = _smb_header(Command.SET_INFO, tree_id=1, session_id=1)
+        response = _dispatch(session, parse_request(header + body))
+        return _get_status(response)
+
     def test_dotdot_escape(self, tmp_path):
         share_dir = tmp_path / "share"
         share_dir.mkdir()
@@ -505,6 +565,106 @@ class TestPathTraversal:
         session = self._setup_session(share_dir)
         status = self._try_create(session, "escape")
         assert status == STATUS_ACCESS_DENIED
+
+    def test_rename_dotdot_escape(self, tmp_path):
+        share_dir = tmp_path / "share"
+        share_dir.mkdir()
+        source = share_dir / "source.txt"
+        source.write_text("payload")
+        outside = tmp_path / "outside.txt"
+        outside.write_text("original")
+
+        session = self._setup_session(share_dir)
+        file_id = self._open_file(session, "source.txt")
+        status = self._try_rename(
+            session,
+            file_id,
+            "..\\outside.txt",
+            replace_if_exists=True,
+        )
+
+        assert status == STATUS_ACCESS_DENIED
+        assert source.read_text() == "payload"
+        assert outside.read_text() == "original"
+
+    def test_rename_absolute_escape(self, tmp_path):
+        share_dir = tmp_path / "share"
+        share_dir.mkdir()
+        source = share_dir / "source.txt"
+        source.write_text("payload")
+        outside = tmp_path / "outside.txt"
+        outside.write_text("original")
+
+        session = self._setup_session(share_dir)
+        file_id = self._open_file(session, "source.txt")
+        status = self._try_rename(
+            session,
+            file_id,
+            str(outside),
+            replace_if_exists=True,
+        )
+
+        assert status == STATUS_ACCESS_DENIED
+        assert source.read_text() == "payload"
+        assert outside.read_text() == "original"
+
+    def test_rename_symlink_escape(self, tmp_path):
+        share_dir = tmp_path / "share"
+        share_dir.mkdir()
+        source = share_dir / "source.txt"
+        source.write_text("payload")
+        outside_dir = tmp_path / "outside"
+        outside_dir.mkdir()
+        link = share_dir / "escape"
+        try:
+            link.symlink_to(outside_dir, target_is_directory=True)
+        except (OSError, NotImplementedError) as e:
+            pytest.skip(f"cannot create symlink on this platform: {e}")
+
+        session = self._setup_session(share_dir)
+        file_id = self._open_file(session, "source.txt")
+        status = self._try_rename(session, file_id, "escape\\payload.txt")
+
+        assert status == STATUS_ACCESS_DENIED
+        assert source.read_text() == "payload"
+        assert not (outside_dir / "payload.txt").exists()
+
+    def test_rename_full_share_relative_path(self, tmp_path):
+        share_dir = tmp_path / "share"
+        subdir = share_dir / "subdir"
+        subdir.mkdir(parents=True)
+        source = subdir / "source.txt"
+        source.write_text("payload")
+
+        session = self._setup_session(share_dir)
+        file_id = self._open_file(session, "subdir\\source.txt")
+        status = self._try_rename(session, file_id, "subdir\\renamed.txt")
+
+        renamed = subdir / "renamed.txt"
+        assert status == STATUS_SUCCESS
+        assert not source.exists()
+        assert renamed.read_text() == "payload"
+        info = session.handles.get(file_id)
+        assert info is not None
+        assert info.path == renamed.resolve()
+
+    def test_rename_rejects_root_directory_handle(self, tmp_path):
+        share_dir = tmp_path / "share"
+        share_dir.mkdir()
+        source = share_dir / "source.txt"
+        source.write_text("payload")
+
+        session = self._setup_session(share_dir)
+        file_id = self._open_file(session, "source.txt")
+        status = self._try_rename(
+            session,
+            file_id,
+            "renamed.txt",
+            root_directory=1,
+        )
+
+        assert status == STATUS_INVALID_PARAMETER
+        assert source.read_text() == "payload"
 
 
 class TestDirectoryOperations:


### PR DESCRIPTION
## Summary

- confine SMB2 `FileRenameInformation` destinations to the configured share root
- reject malformed rename requests and nonzero `RootDirectory` values
- add regression coverage for `..` traversal, absolute host paths, symlink escapes, overwrite attempts, and valid share-relative renames

## Reproduction

This standalone script sends SMB2 `CREATE` and `SET_INFO / FileRenameInformation` requests directly to the server. It attempts to rename an in-share file over an outside file using both `..` traversal and an absolute host path.

```python
#!/usr/bin/env python3

import struct
import tempfile
from pathlib import Path

from quicksand_smb import ShareConfig, SMBConfig, SMBSession, _dispatch
from quicksand_smb._protocol import SMB2_MAGIC, Command, parse_request
from quicksand_smb._status import STATUS_ACCESS_DENIED, STATUS_SUCCESS


def smb_header(command: int, tree_id: int = 1, session_id: int = 1) -> bytes:
    return struct.pack(
        "<4sHHIHHIIQIIQ16s",
        SMB2_MAGIC,
        64,
        1,
        0,
        command,
        1,
        0,
        0,
        0,
        0,
        tree_id,
        session_id,
        b"\x00" * 16,
    )


def response_status(response: bytes) -> int:
    return struct.unpack_from("<I", response, 8)[0]


def open_file(session: SMBSession, filename: str) -> bytes:
    name = filename.encode("utf-16-le")
    body = struct.pack(
        "<HBBIqQIIIIIHHII",
        57,
        0,
        0,
        0,
        0,
        0,
        0x12019F,
        0x80,
        0x07,
        0x01,
        0,
        64 + 56,
        len(name),
        0,
        0,
    )
    response = _dispatch(
        session,
        parse_request(smb_header(Command.CREATE) + body + name),
    )
    if response_status(response) != STATUS_SUCCESS:
        raise RuntimeError(f"CREATE failed: {response_status(response):#010x}")
    return response[128:144]


def rename_file(session: SMBSession, file_id: bytes, new_name: str) -> int:
    name = new_name.encode("utf-16-le")
    rename_info = struct.pack("<B7xQI", True, 0, len(name)) + name
    body = struct.pack(
        "<HBBIHHI16s",
        33,
        0x01,
        10,
        len(rename_info),
        64 + 32,
        0,
        0,
        file_id,
    )
    response = _dispatch(
        session,
        parse_request(smb_header(Command.SET_INFO) + body + rename_info),
    )
    return response_status(response)


def run_case(
    session: SMBSession,
    share: Path,
    source_name: str,
    outside: Path,
    destination: str,
) -> bool:
    source = share / source_name
    source.write_text("payload")
    outside.write_text("original")

    status = rename_file(session, open_file(session, source_name), destination)
    source_preserved = source.read_text() == "payload"
    outside_unchanged = outside.read_text() == "original"
    passed = status == STATUS_ACCESS_DENIED and source_preserved and outside_unchanged

    label = source.stem.removeprefix("source-")
    print(f"{label}_status={status:#010x}")
    print(f"{label}_source_preserved={source_preserved}")
    print(f"{label}_outside_unchanged={outside_unchanged}")
    return passed


with tempfile.TemporaryDirectory() as temp_dir:
    root = Path(temp_dir)
    share = root / "share"
    share.mkdir()
    session = SMBSession(
        config=SMBConfig(
            shares={"SHARE": ShareConfig(host_path=str(share), readonly=False)}
        )
    )
    session.session_id = 1
    session.tree_map[1] = "SHARE"

    dotdot_passed = run_case(
        session,
        share,
        "source-dotdot.txt",
        root / "outside-dotdot.txt",
        "..\\outside-dotdot.txt",
    )
    absolute_outside = root / "outside-absolute.txt"
    absolute_passed = run_case(
        session,
        share,
        "source-absolute.txt",
        absolute_outside,
        str(absolute_outside),
    )

    passed = dotdot_passed and absolute_passed
    print(f"PASS={passed}")
    raise SystemExit(0 if passed else 1)
```

Run from the repository root:

```console
$ uv run python reproduce_smb_rename_escape.py
dotdot_status=0xc0000022
dotdot_source_preserved=True
dotdot_outside_unchanged=True
absolute_status=0xc0000022
absolute_source_preserved=True
absolute_outside_unchanged=True
PASS=True
```

`0xc0000022` is `STATUS_ACCESS_DENIED`.

## Tests

```console
$ uv run pytest tests/unit/smb/ -q --timeout=30
.............................................                            [100%]
45 passed in 0.56s
```

